### PR TITLE
Fix issue with linux removing quotes from arguments

### DIFF
--- a/packaging/pact-broker.sh
+++ b/packaging/pact-broker.sh
@@ -22,4 +22,4 @@ export BUNDLE_GEMFILE="$LIBDIR/vendor/Gemfile"
 unset BUNDLE_IGNORE_CONFIG
 
 # Run the actual app using the bundled Ruby interpreter, with Bundler activated.
-exec "$LIBDIR/ruby/bin/ruby" -rreadline -rbundler/setup -I$LIBDIR/app/lib "$LIBDIR/app/pact-broker.rb" $@
+exec "$LIBDIR/ruby/bin/ruby" -rreadline -rbundler/setup -I$LIBDIR/app/lib "$LIBDIR/app/pact-broker.rb" "$@"

--- a/packaging/pact-mock-service.sh
+++ b/packaging/pact-mock-service.sh
@@ -22,4 +22,4 @@ export BUNDLE_GEMFILE="$LIBDIR/vendor/Gemfile"
 unset BUNDLE_IGNORE_CONFIG
 
 # Run the actual app using the bundled Ruby interpreter, with Bundler activated.
-exec "$LIBDIR/ruby/bin/ruby" -rreadline -rbundler/setup -I$LIBDIR/app/lib "$LIBDIR/app/pact-mock-service.rb" $@
+exec "$LIBDIR/ruby/bin/ruby" -rreadline -rbundler/setup -I$LIBDIR/app/lib "$LIBDIR/app/pact-mock-service.rb" "$@"

--- a/packaging/pact-provider-verifier.sh
+++ b/packaging/pact-provider-verifier.sh
@@ -23,4 +23,4 @@ unset BUNDLE_IGNORE_CONFIG
 unset RUBYGEMS_GEMDEPS # See https://github.com/pact-foundation/pact-mock-service-npm/issues/16
 
 # Run the actual app using the bundled Ruby interpreter, with Bundler activated.
-exec "$LIBDIR/ruby/bin/ruby" -rbundler/setup -rreadline -I$LIBDIR/app/lib "$LIBDIR/app/pact-provider-verifier.rb" $@
+exec "$LIBDIR/ruby/bin/ruby" -rbundler/setup -rreadline -I$LIBDIR/app/lib "$LIBDIR/app/pact-provider-verifier.rb" "$@"

--- a/packaging/pact-publish.sh
+++ b/packaging/pact-publish.sh
@@ -23,4 +23,4 @@ unset BUNDLE_IGNORE_CONFIG
 unset RUBYGEMS_GEMDEPS # See https://github.com/pact-foundation/pact-mock-service-npm/issues/16
 
 # Run the actual app using the bundled Ruby interpreter, with Bundler activated.
-exec "$LIBDIR/ruby/bin/ruby" -rbundler/setup -rreadline -I$LIBDIR/app/lib "$LIBDIR/app/pact-publish.rb" $@
+exec "$LIBDIR/ruby/bin/ruby" -rbundler/setup -rreadline -I$LIBDIR/app/lib "$LIBDIR/app/pact-publish.rb" "$@"

--- a/packaging/pact-stub-service.sh
+++ b/packaging/pact-stub-service.sh
@@ -22,4 +22,4 @@ export BUNDLE_GEMFILE="$LIBDIR/vendor/Gemfile"
 unset BUNDLE_IGNORE_CONFIG
 
 # Run the actual app using the bundled Ruby interpreter, with Bundler activated.
-exec "$LIBDIR/ruby/bin/ruby" -rreadline -rbundler/setup -I$LIBDIR/app/lib "$LIBDIR/app/pact-stub-service.rb" $@
+exec "$LIBDIR/ruby/bin/ruby" -rreadline -rbundler/setup -I$LIBDIR/app/lib "$LIBDIR/app/pact-stub-service.rb" "$@"


### PR DESCRIPTION
One of the guys at SEEK ran into an issue with Pact-Net on linux, after we introduced the latest ruby standalone core which passes the Consumer and Provider name as command line arguments to the pact-mock-service.

The issue occurs when you specify a consumer or provider name that contains a space character e.g. "--provider Something API". When the .NET wrapper calls the pact-mock-service script, it encloses the params in quotes, however they are removed.

It appears that bash on linux is removing the " characters from arguments. See https://serverfault.com/questions/269592/bash-quotes-getting-stripped-when-a-command-is-passed-as-argument-to-a-function