### PR TITLE
fix(install) use posix uname -m instead of -i

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -10,7 +10,7 @@ set -e
 uname_output=$(uname)
 case $uname_output in
   'Linux')
-    linux_uname_output=$(uname -i)
+    linux_uname_output=$(uname -m)
     case $linux_uname_output in
       'x86_64')
         os='linux-x86_64'


### PR DESCRIPTION
This small change fixes the install on linux.

Steps to reproduce using docker:
```
> docker run -it --rm golang:1.9 bash
> uname -i
unknown
> uname -m
x86_64
> curl -fsSL https://raw.githubusercontent.com/pact-foundation/pact-ruby-standalone/master/install.sh | bash
Sorry, you'll need to install the pact-ruby-standalone manually.
```