### PR TITLE
making shell scripts more POSIX

### DIFF
--- a/packaging/pact-broker.sh
+++ b/packaging/pact-broker.sh
@@ -4,7 +4,8 @@ set -e
 SOURCE="$0"
 while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
   TARGET="$(readlink "$SOURCE")"
-  if [[ $TARGET == /* ]]; then
+  START="$( echo "$TARGET" | cut -c 1 )"
+  if [ "$START" = "/" ]; then
     SOURCE="$TARGET"
   else
     DIR="$( dirname "$SOURCE" )"

--- a/packaging/pact-message.sh
+++ b/packaging/pact-message.sh
@@ -4,7 +4,8 @@ set -e
 SOURCE="$0"
 while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
   TARGET="$(readlink "$SOURCE")"
-  if [[ $TARGET == /* ]]; then
+  START="$( echo "$TARGET" | cut -c 1 )"
+  if [ "$START" = "/" ]; then
     SOURCE="$TARGET"
   else
     DIR="$( dirname "$SOURCE" )"

--- a/packaging/pact-mock-service.sh
+++ b/packaging/pact-mock-service.sh
@@ -4,7 +4,8 @@ set -e
 SOURCE="$0"
 while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
   TARGET="$(readlink "$SOURCE")"
-  if [[ $TARGET == /* ]]; then
+  START="$( echo "$TARGET" | cut -c 1 )"
+  if [ "$START" = "/" ]; then
     SOURCE="$TARGET"
   else
     DIR="$( dirname "$SOURCE" )"

--- a/packaging/pact-provider-verifier.sh
+++ b/packaging/pact-provider-verifier.sh
@@ -4,7 +4,8 @@ set -e
 SOURCE="${BASH_SOURCE[0]}"
 while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
   TARGET="$(readlink "$SOURCE")"
-  if [[ $TARGET == /* ]]; then
+  START="$( echo "$TARGET" | cut -c 1 )"
+  if [ "$START" = "/" ]; then
     SOURCE="$TARGET"
   else
     DIR="$( dirname "$SOURCE" )"

--- a/packaging/pact-publish.sh
+++ b/packaging/pact-publish.sh
@@ -4,7 +4,8 @@ set -e
 SOURCE="${BASH_SOURCE[0]}"
 while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
   TARGET="$(readlink "$SOURCE")"
-  if [[ $TARGET == /* ]]; then
+  START="$( echo "$TARGET" | cut -c 1 )"
+  if [ "$START" = "/" ]; then
     SOURCE="$TARGET"
   else
     DIR="$( dirname "$SOURCE" )"

--- a/packaging/pact-stub-service.sh
+++ b/packaging/pact-stub-service.sh
@@ -4,7 +4,8 @@ set -e
 SOURCE="$0"
 while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
   TARGET="$(readlink "$SOURCE")"
-  if [[ $TARGET == /* ]]; then
+  START="$( echo "$TARGET" | cut -c 1 )"
+  if [ "$START" = "/" ]; then
     SOURCE="$TARGET"
   else
     DIR="$( dirname "$SOURCE" )"

--- a/packaging/pact.sh
+++ b/packaging/pact.sh
@@ -4,7 +4,8 @@ set -e
 SOURCE="$0"
 while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
   TARGET="$(readlink "$SOURCE")"
-  if [[ $TARGET == /* ]]; then
+  START="$( echo "$TARGET" | cut -c 1 )"
+  if [ "$START" = "/" ]; then
     SOURCE="$TARGET"
   else
     DIR="$( dirname "$SOURCE" )"


### PR DESCRIPTION
I have modified the shell scripts under /packaging to use be more POSIX friendly. The change is around the test condition for the if statement to remove bash specific logic.

I have tested the new script with bash, dash and posh (Policy-compliant Ordinary SHell) and the condition was evaluated correctly.