### PR TITLE
fix: unset BUNDLE_APP_CONFIG to prevent Ruby contamination

### DIFF
--- a/packaging/pact-broker.bat
+++ b/packaging/pact-broker.bat
@@ -7,6 +7,7 @@ CALL :RESOLVE "%RUNNING_PATH%\.." ROOT_PATH
 set "BUNDLE_GEMFILE=%ROOT_PATH%\lib\vendor\Gemfile"
 set BUNDLE_IGNORE_CONFIG=
 set RUBYGEMS_GEMDEPS=
+set BUNDLE_APP_CONFIG=
 set BUNDLE_FROZEN=1
 
 :: Run the actual app using the bundled Ruby interpreter, with Bundler activated.

--- a/packaging/pact-message.bat
+++ b/packaging/pact-message.bat
@@ -7,6 +7,7 @@ CALL :RESOLVE "%RUNNING_PATH%\.." ROOT_PATH
 set "BUNDLE_GEMFILE=%ROOT_PATH%\lib\vendor\Gemfile"
 set BUNDLE_IGNORE_CONFIG=
 set RUBYGEMS_GEMDEPS=
+set BUNDLE_APP_CONFIG=
 set BUNDLE_FROZEN=1
 
 :: Run the actual app using the bundled Ruby interpreter, with Bundler activated.

--- a/packaging/pact-mock-service.bat
+++ b/packaging/pact-mock-service.bat
@@ -7,6 +7,7 @@ CALL :RESOLVE "%RUNNING_PATH%\.." ROOT_PATH
 set "BUNDLE_GEMFILE=%ROOT_PATH%\lib\vendor\Gemfile"
 set BUNDLE_IGNORE_CONFIG=
 set RUBYGEMS_GEMDEPS=
+set BUNDLE_APP_CONFIG=
 set BUNDLE_FROZEN=1
 
 :: Run the actual app using the bundled Ruby interpreter, with Bundler activated.

--- a/packaging/pact-provider-verifier.bat
+++ b/packaging/pact-provider-verifier.bat
@@ -7,6 +7,7 @@ CALL :RESOLVE "%RUNNING_PATH%\.." ROOT_PATH
 set "BUNDLE_GEMFILE=%ROOT_PATH%\lib\vendor\Gemfile"
 set BUNDLE_IGNORE_CONFIG=
 set RUBYGEMS_GEMDEPS=
+set BUNDLE_APP_CONFIG=
 set BUNDLE_FROZEN=1
 
 :: Run the actual app using the bundled Ruby interpreter, with Bundler activated.

--- a/packaging/pact-publish.bat
+++ b/packaging/pact-publish.bat
@@ -7,6 +7,7 @@ CALL :RESOLVE "%RUNNING_PATH%\.." ROOT_PATH
 set "BUNDLE_GEMFILE=%ROOT_PATH%\lib\vendor\Gemfile"
 set BUNDLE_IGNORE_CONFIG=
 set RUBYGEMS_GEMDEPS=
+set BUNDLE_APP_CONFIG=
 set BUNDLE_FROZEN=1
 
 :: Run the actual app using the bundled Ruby interpreter, with Bundler activated.

--- a/packaging/pact-stub-service.bat
+++ b/packaging/pact-stub-service.bat
@@ -7,6 +7,7 @@ CALL :RESOLVE "%RUNNING_PATH%\.." ROOT_PATH
 set "BUNDLE_GEMFILE=%ROOT_PATH%\lib\vendor\Gemfile"
 set BUNDLE_IGNORE_CONFIG=
 set RUBYGEMS_GEMDEPS=
+set BUNDLE_APP_CONFIG=
 set BUNDLE_FROZEN=1
 
 :: Run the actual app using the bundled Ruby interpreter, with Bundler activated.

--- a/packaging/pact.bat
+++ b/packaging/pact.bat
@@ -7,6 +7,7 @@ CALL :RESOLVE "%RUNNING_PATH%\.." ROOT_PATH
 set "BUNDLE_GEMFILE=%ROOT_PATH%\lib\vendor\Gemfile"
 set BUNDLE_IGNORE_CONFIG=
 set RUBYGEMS_GEMDEPS=
+set BUNDLE_APP_CONFIG=
 set BUNDLE_FROZEN=1
 
 :: Run the actual app using the bundled Ruby interpreter, with Bundler activated.


### PR DESCRIPTION
Issue reported on Slack. The Ruby environment is contaminated by this environment variable if present.

See https://github.com/pact-foundation/pact-mock-service-npm/issues/16. The current issue has also been experienced (reproduced) on CircleCI. 

One option is to remove _any_ environment variables with `RUBYGEMS`, `RUBY`, `GEM` or related prefixes. But the issue has come up so rarely, I think this single env-var approach is much safer.

I've been able to reproduce the issue locally by exporting that variable (see image).

![Screen Shot 2020-04-14 at 5 39 21 pm](https://user-images.githubusercontent.com/53900/79198650-267aa000-7e77-11ea-8d93-5668255dc0d9.png)
