### PR TITLE
Explicitly use bash for packaging shell scripts

### DIFF
--- a/packaging/pact-broker.sh
+++ b/packaging/pact-broker.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 set -e
 
 SOURCE="$0"

--- a/packaging/pact-message.sh
+++ b/packaging/pact-message.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 set -e
 
 SOURCE="$0"

--- a/packaging/pact-mock-service.sh
+++ b/packaging/pact-mock-service.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 set -e
 
 SOURCE="$0"

--- a/packaging/pact-provider-verifier.sh
+++ b/packaging/pact-provider-verifier.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 SOURCE="${BASH_SOURCE[0]}"

--- a/packaging/pact-publish.sh
+++ b/packaging/pact-publish.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 SOURCE="${BASH_SOURCE[0]}"

--- a/packaging/pact-stub-service.sh
+++ b/packaging/pact-stub-service.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 set -e
 
 SOURCE="$0"

--- a/packaging/pact.sh
+++ b/packaging/pact.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 set -e
 
 SOURCE="$0"


### PR DESCRIPTION
`pact-ruby-standalone` appears to be used by the [@pact-foundation/pact](https://www.npmjs.com/package/@pact-foundation/pact) NPM package.

On macOS Catalina, `/bin/sh` defaults to `zsh` when it previously used to default to `bash` in earlier versions of macOS.

This change breaks the following line that appears in many of the packaging scripts, which does not work properly in `zsh`:

`DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"`

Since I imagine most consumers of this package will have `bash` installed, I updated the shebang in all of the packaging scripts to explicitly use the default version of `bash` via `/usr/bin/env`, rather than using the more general `/bin/sh`, which may not actually be `bash`.