### PR TITLE
Fix Bash Shebang Headers

### DIFF
--- a/packaging/pact-broker.sh
+++ b/packaging/pact-broker.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 set -e
 
 SOURCE="$0"

--- a/packaging/pact-message.sh
+++ b/packaging/pact-message.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 set -e
 
 SOURCE="$0"

--- a/packaging/pact-mock-service.sh
+++ b/packaging/pact-mock-service.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 set -e
 
 SOURCE="$0"

--- a/packaging/pact-provider-verifier.sh
+++ b/packaging/pact-provider-verifier.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 set -e
 
 SOURCE="${BASH_SOURCE[0]}"

--- a/packaging/pact-publish.sh
+++ b/packaging/pact-publish.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 set -e
 
 SOURCE="${BASH_SOURCE[0]}"

--- a/packaging/pact-stub-service.sh
+++ b/packaging/pact-stub-service.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 set -e
 
 SOURCE="$0"

--- a/packaging/pact.sh
+++ b/packaging/pact.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 set -e
 
 SOURCE="$0"

--- a/script/docker-functions
+++ b/script/docker-functions
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 IMAGE=pact-ruby-standalone-bundle-base
 RELEASE_IMAGE=pact-ruby-standalone-release-base

--- a/script/prepare-release-in-github-workflow.sh
+++ b/script/prepare-release-in-github-workflow.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 set -Eeuo pipefail
 

--- a/script/release.sh
+++ b/script/release.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 set -e
 source script/docker-functions

--- a/script/update-and-release.sh
+++ b/script/update-and-release.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 set -e
 

--- a/script/update-in-github-workflow.sh
+++ b/script/update-in-github-workflow.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 set -Eeuo
 

--- a/script/update.sh
+++ b/script/update.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 source script/docker-functions
 


### PR DESCRIPTION
A number of complaints from multiple runtimes have been raised about the error:

`err > env: can't execute 'bash': No such file or directory`

This fixes by using `/bin/bash`, which is available in alpine. It's `/usr/bin/env bash` which sometimes fails.

The [following direct answer from StackOverflow](https://stackoverflow.com/a/16365367/1548557) details some of the differences. Needless to say this works for me, and is already used in a few places in your code. 