### PR TITLE
modified install.sh to recognize Macbook M1

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -10,7 +10,7 @@ case $(uname -sm) in
   'Linux x86_64')
     os='linux-x86_64'
     ;;
-  'Darwin x86' | 'Darwin x86_64')
+  'Darwin x86' | 'Darwin x86_64' | 'Darwin arm64')
     os='osx'
     ;;
   *)


### PR DESCRIPTION
Currently, install script does not recognize Arm architecture for Macbook M1 laptops.
I just added one more possible value to fix that.