### PR TITLE
Fix/unset bundle app config shell scripts

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -33,7 +33,7 @@ TEST_ALPINE_ARM64_TASK_TEMPLATE: &TEST_ALPINE_ARM64_TASK_TEMPLATE
 
 TEST_TASK_TEMPLATE: &TEST_TASK_TEMPLATE
   <<: *TEST_ALPINE_ARM64_TASK_TEMPLATE
-  test_plugin_cli_script: pact-plugin-cli
+  test_plugin_cli_script: pact-plugin-cli --help
 
 DOCKER_ARGS_ARM64_TEMPLATE: &DOCKER_ARGS_ARM64_TEMPLATE
     docker_arguments:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -18,16 +18,22 @@ STANDALONE_INSTALL_TASK_TEMPLATE: &STANDALONE_INSTALL_TASK_TEMPLATE
     && ls pact/bin/ \
     && ls /usr/local/bin
 
-TEST_TASK_TEMPLATE: &TEST_TASK_TEMPLATE
+## This is a yak shave relating to https://github.com/pact-foundation/pact-ruby-standalone/issues/102
+## pact-plugin-cli is not compatible with current guidance for alpine aarch64 with official arm64v8/alpine 
+## This task is reused in TEST_TASK_TEMPLATE adding in the pact-plugin-cli so its tested for other combos
+TEST_ALPINE_ARM64_TASK_TEMPLATE: &TEST_ALPINE_ARM64_TASK_TEMPLATE
   test_script: | # would rather avoid the commands here, but also want to keep the images clean so they can be easily used by users
       uname -a 
       pact-broker --help
       pact-message --help
       pact-mock-service --help
-      pact-plugin-cli --help
       pact-provider-verifier --help
       pact-stub-service --help
       pactflow --help
+
+TEST_TASK_TEMPLATE: &TEST_TASK_TEMPLATE
+  <<: *TEST_ALPINE_ARM64_TASK_TEMPLATE
+  test_plugin_cli_script: pact-plugin-cli
 
 DOCKER_ARGS_ARM64_TEMPLATE: &DOCKER_ARGS_ARM64_TEMPLATE
     docker_arguments:
@@ -133,7 +139,7 @@ alpine_arm64_task:
   arm_container:
     dockerfile: Dockerfile.alpine.arm64
     <<: *DOCKER_ARGS_ARM64_TEMPLATE
-  <<: *TEST_TASK_TEMPLATE
+  <<: *TEST_ALPINE_ARM64_TASK_TEMPLATE
 ubuntu_arm64_task: 
   arm_container:
     dockerfile: Dockerfile.ubuntu
@@ -144,7 +150,6 @@ debian_arm64_task:
     dockerfile: Dockerfile.debian.slim
     <<: *DOCKER_ARGS_ARM64_TEMPLATE
   <<: *TEST_TASK_TEMPLATE
-
 ## Test published standalone against x64 versions
 alpine_x64_task: 
   container:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -41,8 +41,9 @@ DOCKER_ARGS_X64_TEMPLATE: &DOCKER_ARGS_X64_TEMPLATE
 
 # This task packages up the pact-ruby-standalone for all arches
 # it uses the ruby image to save time
+# BINARY_ env vars are set, so we only test our platform specific pact-ruby-standalone
 builder_linux_x64_task: 
-  env: ## BINARY_ env vars are set, so we only test our platform specific pact-ruby-standalone
+  env:
     BINARY_OS: linux
     BINARY_ARCH: x86_64
     PATH: "$HOME/.rbenv/bin:/root/.rbenv/shims:$PATH"
@@ -64,7 +65,7 @@ builder_linux_slim_x64_task:
   << : *BUILD_TEST_TASK_TEMPLATE
 
 builder_linux_arm64_task: 
-  env: ## BINARY_ env vars are set, so we only test our platform specific pact-ruby-standalone
+  env: 
     BINARY_OS: linux
     BINARY_ARCH: arm64
     PATH: "$HOME/.rbenv/bin:/root/.rbenv/shims:$PATH"
@@ -114,7 +115,7 @@ builder_ruby_source_linux_task:
   << : *BUILD_TEST_TASK_TEMPLATE
 
 # This task packages up the pact-ruby-standalone for all arches
-# using macOS and then tests it out
+# using macOS and then tests out the arm64 package
 macosx_arm64_task: 
   macos_instance:
     image: ghcr.io/cirruslabs/macos-ventura-base:latest
@@ -127,31 +128,33 @@ macosx_arm64_task:
   << : *BUILD_TEST_TASK_TEMPLATE
 
 
+## Test published standalone against arm64 versions
 alpine_arm64_task: 
   arm_container:
     dockerfile: Dockerfile.alpine.arm64
     <<: *DOCKER_ARGS_ARM64_TEMPLATE
-  <<: *TEST_TASK_TEMPLATE
-alpine_x64_task: 
-  container:
-    dockerfile: Dockerfile.alpine.x64
-    <<: *DOCKER_ARGS_X64_TEMPLATE
   <<: *TEST_TASK_TEMPLATE
 ubuntu_arm64_task: 
   arm_container:
     dockerfile: Dockerfile.ubuntu
     <<: *DOCKER_ARGS_ARM64_TEMPLATE
   <<: *TEST_TASK_TEMPLATE
+debian_arm64_task: 
+  arm_container:
+    dockerfile: Dockerfile.debian.slim
+    <<: *DOCKER_ARGS_ARM64_TEMPLATE
+  <<: *TEST_TASK_TEMPLATE
+
+## Test published standalone against x64 versions
+alpine_x64_task: 
+  container:
+    dockerfile: Dockerfile.alpine.x64
+    <<: *DOCKER_ARGS_X64_TEMPLATE
+  <<: *TEST_TASK_TEMPLATE
 ubuntu_x64_task: 
   container:
     dockerfile: Dockerfile.ubuntu
     <<: *DOCKER_ARGS_X64_TEMPLATE
-  <<: *TEST_TASK_TEMPLATE
-debian_arm64_task: 
-  arm_container:
-  container:
-    dockerfile: Dockerfile.debian.slim
-    <<: *DOCKER_ARGS_ARM64_TEMPLATE
   <<: *TEST_TASK_TEMPLATE
 debian_x64_task: 
   container:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,42 +1,109 @@
+env:
+  PACT_VERSION: 2.0.0
+
+
 BUILD_TEST_TASK_TEMPLATE: &BUILD_TEST_TASK_TEMPLATE
   arch_check_script:
     - uname -am
   install_script: bundle install
   build_script: bundle exec rake package
-  test_script: chmod +x ./script/test.sh && ./script/test.sh
+  test_script: chmod +x ./script/unpack-and-test.sh && ./script/unpack-and-test.sh
 
-linux_arm64_task: 
+STANDALONE_INSTALL_TASK_TEMPLATE: &STANDALONE_INSTALL_TASK_TEMPLATE
+  install_script: |
+    wget -q https://github.com/pact-foundation/pact-ruby-standalone/releases/download/v${PACT_VERSION}/pact-${PACT_VERSION}-linux-${TARGET_ARCH}.tar.gz \
+    && tar xzf pact-${PACT_VERSION}-linux-${TARGET_ARCH}.tar.gz \
+    && rm -rf pact-${PACT_VERSION}-linux-${TARGET_ARCH}.tar.gz \
+    && ln -s $PWD/pact/bin/* /usr/local/bin \
+    && ls pact/bin/ \
+    && ls /usr/local/bin
+
+TEST_TASK_TEMPLATE: &TEST_TASK_TEMPLATE
+  test_script: | # would rather avoid the commands here, but also want to keep the images clean so they can be easily used by users
+      uname -a 
+      pact-broker --help
+      pact-message --help
+      pact-mock-service --help
+      pact-plugin-cli --help
+      pact-provider-verifier --help
+      pact-stub-service --help
+      pactflow --help
+
+DOCKER_ARGS_ARM64_TEMPLATE: &DOCKER_ARGS_ARM64_TEMPLATE
+    docker_arguments:
+      PACT_VERSION: $PACT_VERSION
+      TARGET_ARCH: arm64
+
+DOCKER_ARGS_X64_TEMPLATE: &DOCKER_ARGS_X64_TEMPLATE
+    docker_arguments:
+      PACT_VERSION: $PACT_VERSION
+      TARGET_ARCH: x86_64
+
+# This task packages up the pact-ruby-standalone for all arches
+# it uses the ruby image to save time
+builder_linux_x64_task: 
+  env: ## BINARY_ env vars are set, so we only test our platform specific pact-ruby-standalone
+    BINARY_OS: linux
+    BINARY_ARCH: x86_64
+    PATH: "$HOME/.rbenv/bin:/root/.rbenv/shims:$PATH"
+  container:
+    image: ruby:3.2.2
+  pre_req_script:
+      apt update --yes && apt install --yes zip
+  << : *BUILD_TEST_TASK_TEMPLATE
+
+builder_linux_slim_x64_task: 
+  env:
+    BINARY_OS: linux
+    BINARY_ARCH: x86_64
+    PATH: "$HOME/.rbenv/bin:/root/.rbenv/shims:$PATH"
+  container:
+    image: ruby:3.2.2-slim
+  pre_req_script:
+      apt update --yes && apt install --yes zip curl
+  << : *BUILD_TEST_TASK_TEMPLATE
+
+builder_linux_arm64_task: 
+  env: ## BINARY_ env vars are set, so we only test our platform specific pact-ruby-standalone
+    BINARY_OS: linux
+    BINARY_ARCH: arm64
+    PATH: "$HOME/.rbenv/bin:/root/.rbenv/shims:$PATH"
+  arm_container:
+    image: ruby:3.2.2
+  pre_req_script:
+      apt update --yes && apt install --yes zip
+  << : *BUILD_TEST_TASK_TEMPLATE
+
+builder_linux_slim_arm64_task: 
   env:
     BINARY_OS: linux
     BINARY_ARCH: arm64
     PATH: "$HOME/.rbenv/bin:/root/.rbenv/shims:$PATH"
-  ## *******************************  
-  ## Fails on Ruby:3.2.2 based image - fine on ubuntu latest, but installing ruby 3.2.2 from source takes a good while (few minutes)
-  ## executing ./pact/bin/pactflow
-  ## /tmp/cirrus-ci/working-dir/pkg/pact/lib/ruby/lib/ruby/3.2.0/bundler/definition.rb:524:in `materialize': Could not find pact-1.63.0, pact-message-0.11.1, pact-mock_service-3.11.0, pact-provider-verifier-1.36.1, pact_broker-client-1.66.1, webrick-1.8.1, rack-2.2.7, pact-support-1.19.0, rack-test-2.1.0, rspec-3.12.0, term-ansicolor-1.7.1, thor-1.2)
-  ##   from /tmp/cirrus-ci/working-dir/pkg/pact/lib/ruby/lib/ruby/3.2.0/bundler/definition.rb:197:in `specs'
-  ##   from /tmp/cirrus-ci/working-dir/pkg/pact/lib/ruby/lib/ruby/3.2.0/bundler/definition.rb:254:in `specs_for'
-  ##   from /tmp/cirrus-ci/working-dir/pkg/pact/lib/ruby/lib/ruby/3.2.0/bundler/runtime.rb:18:in `setup'
-  ##   from /tmp/cirrus-ci/working-dir/pkg/pact/lib/ruby/lib/ruby/3.2.0/bundler.rb:171:in `setup'
-  ##   from /tmp/cirrus-ci/working-dir/pkg/pact/lib/ruby/lib/ruby/3.2.0/bundler/setup.rb:23:in `block in <top (required)>'
-  ##   from /tmp/cirrus-ci/working-dir/pkg/pact/lib/ruby/lib/ruby/3.2.0/bundler/ui/shell.rb:159:in `with_level'
-  ##   from /tmp/cirrus-ci/working-dir/pkg/pact/lib/ruby/lib/ruby/3.2.0/bundler/ui/shell.rb:111:in `silence'
-  ##   from /tmp/cirrus-ci/working-dir/pkg/pact/lib/ruby/lib/ruby/3.2.0/bundler/setup.rb:23:in `<top (required)>'
-  ##   from <internal:/tmp/cirrus-ci/working-dir/pkg/pact/lib/ruby/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
-  ##   from <internal:/tmp/cirrus-ci/working-dir/pkg/pact/lib/ruby/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:85:in `require' 
-  ## *******************************  
-  # container:
-  #   image: ruby:3.2.2
-  #   architecture: arm64
-  # pre_req_script: |
-  #     apt update --yes && apt install --yes git curl libssl-dev libreadline-dev zlib1g-dev autoconf bison build-essential libyaml-dev libreadline-dev libncurses5-dev libffi-dev libgdbm-dev zip
-  #     ruby --version
-  #     bundler --version
   arm_container:
+    image: ruby:3.2.2-slim
+  pre_req_script:
+      apt update --yes && apt install --yes zip curl
+  << : *BUILD_TEST_TASK_TEMPLATE
+
+# This task packages up the pact-ruby-standalone for all arches
+# it uses the latest ubuntu image to show it building from source
+# it takes ages but helps show all the dependencies
+## Skipped unless commit message "ci(cirrus): test builder_ruby_source_linux"
+## cirrus run "builder_ruby_source_linux" --output github-actions -e CIRRUS_CHANGE_TITLE="ci(cirrus): builder_ruby_source_linux"
+builder_ruby_source_linux_task:
+  only_if: $CIRRUS_CHANGE_TITLE =~ 'ci\(cirrus\):.*builder_ruby_source_linux'
+  env: ## BINARY_ env vars are set, so we only test our platform specific pact-ruby-standalone
+    BINARY_OS: linux
+    BINARY_ARCH: arm64
+    PATH: "$HOME/.rbenv/bin:/root/.rbenv/shims:$PATH"
+  container:
     image: ubuntu:latest
-    architecture: arm64  
   install_ruby_from_source_script: |
-      apt update --yes && apt install --yes git curl libssl-dev libreadline-dev zlib1g-dev autoconf bison build-essential libyaml-dev libreadline-dev libncurses5-dev libffi-dev libgdbm-dev zip
+      apt update --yes && apt install --yes git curl \
+                                            libssl-dev libreadline-dev zlib1g-dev \
+                                            autoconf bison build-essential libyaml-dev \
+                                            libreadline-dev libncurses5-dev libffi-dev \
+                                            libgdbm-dev zip
       curl -fsSL https://github.com/rbenv/rbenv-installer/raw/HEAD/bin/rbenv-installer | bash
       echo 'eval "$(rbenv init -)"' >> ~/.bashrc
       source ~/.bashrc
@@ -46,6 +113,8 @@ linux_arm64_task:
       bundler --version
   << : *BUILD_TEST_TASK_TEMPLATE
 
+# This task packages up the pact-ruby-standalone for all arches
+# using macOS and then tests it out
 macosx_arm64_task: 
   macos_instance:
     image: ghcr.io/cirruslabs/macos-ventura-base:latest
@@ -57,3 +126,44 @@ macosx_arm64_task:
     - ruby --version
   << : *BUILD_TEST_TASK_TEMPLATE
 
+
+alpine_arm64_task: 
+  arm_container:
+    dockerfile: Dockerfile.alpine.arm64
+    <<: *DOCKER_ARGS_ARM64_TEMPLATE
+  <<: *TEST_TASK_TEMPLATE
+alpine_x64_task: 
+  container:
+    dockerfile: Dockerfile.alpine.x64
+    <<: *DOCKER_ARGS_X64_TEMPLATE
+  <<: *TEST_TASK_TEMPLATE
+ubuntu_arm64_task: 
+  arm_container:
+    dockerfile: Dockerfile.ubuntu
+    <<: *DOCKER_ARGS_ARM64_TEMPLATE
+  <<: *TEST_TASK_TEMPLATE
+ubuntu_x64_task: 
+  container:
+    dockerfile: Dockerfile.ubuntu
+    <<: *DOCKER_ARGS_X64_TEMPLATE
+  <<: *TEST_TASK_TEMPLATE
+debian_arm64_task: 
+  arm_container:
+  container:
+    dockerfile: Dockerfile.debian.slim
+    <<: *DOCKER_ARGS_ARM64_TEMPLATE
+  <<: *TEST_TASK_TEMPLATE
+debian_x64_task: 
+  container:
+    dockerfile: Dockerfile.debian.slim
+    <<: *DOCKER_ARGS_X64_TEMPLATE
+  <<: *TEST_TASK_TEMPLATE
+
+## The following task will fail, until the PR addressing https://github.com/pact-foundation/pact-ruby-standalone/issues/56 is merged
+## and released. Shown working in the builder_linux_task task
+# ruby_3_2_2_task:
+#   arm_container:
+#     image: ruby:3.2.2
+#     <<: *DOCKER_ARGS_ARM64_TEMPLATE
+#   <<: *STANDALONE_INSTALL_TASK_TEMPLATE
+#   <<: *TEST_TASK_TEMPLATE

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,10 +40,10 @@ jobs:
     - name: Download all workflow run artifacts
       uses: actions/download-artifact@v3
     - name: test ${{ matrix.os }} package
-      run: ./script/test.sh
+      run: ./script/unpack-and-test.sh
     - name: test x86 package
       if: ${{ runner.os == 'Windows'}}
-      run: ./script/test.sh
+      run: ./script/unpack-and-test.sh
       env: 
         BINARY_OS: 'windows'
         BINARY_ARCH: 'x86'

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -1,0 +1,336 @@
+## Packaging
+
+pact-ruby-standalone is packaged with `traveling-ruby`
+
+### Building the `traveling-ruby` runtime
+
+1. Build the traveling ruby runtime
+   1. `git clone xyz`
+
+For macOS - it will build for arm64 or x86_64 depending on your processor
+
+    cd osx
+    rake stash_conflicting_paths
+    rake --trace
+    rake unstash_conflicting_paths
+
+For macOS x86_64 on an m1 machine
+
+    sudo softwareupdate --install-rosetta --agree-to-license
+    cd osx
+    rake stash_conflicting_paths
+    arch -x86_64 rake --trace
+    rake unstash_conflicting_paths
+
+For Linux
+
+These are built via docker images, using [Phusions Holy Build Box](https://github.com/phusion/holy-build-box) so don't have to be built on a linux host. You can skip the `rake image` step, and it will pull from the image from Dockerhub
+
+For Linux x86_64
+
+    cd linux
+    ARCHITECTURES="x86_64" rake image
+    ARCHITECTURES="x86_64" rake
+
+For Linux arm64
+
+    cd linux
+    ARCHITECTURES="arm64" rake image
+    ARCHITECTURES="arm64" rake
+
+For Windows
+
+These dont package ruby gems, just the ruby runtime.
+
+Script is designed to run on Linux, but can be run on macOS or windows.
+
+1. macOS users will need `7zz` as an alias for `7z` - `brew install sevenzip`
+2. linux users will need `7z`
+3. windows users will need a `bash` shell, or prefix commands with `bash -c 'command'`
+   1. You'll also need to modify the commands below, for the necessary version
+   2. Happy to accept a PR to make it more powershell/cmd prompt friendly
+
+For windows x86_64
+
+    cd windows
+    bash -c 'mkdir -p cache output/3.2.2'
+    bash -c './build-ruby -a x86 -r 3.2.2 cache output/3.2.2'
+    bash -c './package -r traveling-ruby-20230428-3.2.2-x86-windows.tar.gz output/3.2.2'
+
+For windows x86
+
+    bash -c 'mkdir -p cache output/3.2.2'
+    bash -c './build-ruby -a x86_64 -r 3.2.2 cache output/3.2.2'
+    bash -c './package -r traveling-ruby-20230428-3.2.2-x86_64-windows.tar.gz output/3.2.2'
+
+### Building the pact-ruby-standalone packages
+
+The following steps are the same, whether you are using the published traveling-ruby binaries, or you have built your own
+
+Setup your gems
+
+    bundle install
+
+Build all the pact-ruby-standalone packages
+
+    bundle exec rake package
+
+Build only selected platforms
+
+    bundle exec rake package:linux:arm64
+    bundle exec rake package:linux:x64
+    bundle exec rake package:osx:arm64
+    bundle exec rake package:osx:x64
+    bundle exec rake package:windows:x64
+    bundle exec rake package:windows:x86
+
+#### Using your own built `traveling-ruby` packages
+
+1. in `tasks/package.rake`
+   1. comment out the `download_runtime` line, for whichever binary you don't want to want to download from the uploaded source but instead, use your own
+
+    ```ruby
+    file "build/traveling-ruby-#{TRAVELING_RUBY_VERSION}-linux-x86_64.tar.gz" do
+    # download_runtime(TRAVELING_RUBY_VERSION, "linux-x86_64")
+    end
+
+    file "build/traveling-ruby-#{TRAVELING_RUBY_VERSION}-linux-arm64.tar.gz" do
+    # download_runtime(TRAVELING_RUBY_VERSION, "linux-arm64")
+    end
+
+    file "build/traveling-ruby-#{TRAVELING_RUBY_VERSION}-osx-x86_64.tar.gz" do
+    # download_runtime(TRAVELING_RUBY_VERSION, "osx-x86_64")
+    end
+
+    file "build/traveling-ruby-#{TRAVELING_RUBY_VERSION}-osx-arm64.tar.gz" do
+    # download_runtime(TRAVELING_RUBY_VERSION, "osx-arm64")
+    end
+
+    file "build/traveling-ruby-#{TRAVELING_RUBY_VERSION}-windows-x86_64.tar.gz" do
+    # download_runtime(TRAVELING_RUBY_VERSION, "windows-x86_64")
+    end
+    file "build/traveling-ruby-#{TRAVELING_RUBY_VERSION}-windows-x86.tar.gz" do
+    # download_runtime(TRAVELING_RUBY_VERSION, "windows-x86")
+    end
+    ```
+
+2. Copy your built `traveling-ruby` package into the `build` folder
+3. Ensure the version number in `tasks/package.rake` matches your package name
+   1. eg
+      1. `traveling-ruby-20230508-3.2.2-linux-arm64.tar.gz`
+
+    ```ruby
+    TRAVELING_RUBY_VERSION = "20230508-3.2.2"
+    ```
+
+4. Run `bundle exec rake package` as before
+
+## Supported Platforms
+
+| OS     | Ruby      | Architecture | Supported |
+| -------| ------- | ------------ | --------- |
+| OSX    | 3.2.2     | x86_64       | ✅         |
+| OSX    | 3.2.2     | aarch64 (arm)| ✅         |
+| Linux  | 3.2.2   | x86_64       | ✅         |
+| Linux  | 3.2.2   | aarch64 (arm)| ✅          |
+| Windows| 3.2.2 | x86_64       | ✅        |
+| Windows| 3.2.2 | x86       | ✅        |
+| Windows| 3.2.2 | aarch64 (via x86 emulation) |  ✅        |
+
+## Testing
+
+We aim to support testing locally on all platforms, as well as using automated CI scripts.
+
+We suggest avoiding putting logic out of CI workflow yaml files and instead prefer shell files.
+
+We believe it makes testing locally so much easier.
+
+> The workflow files should just contain code that wires the CI platform into your own scripts.
+
+Because of this, you should find a `script` or `scripts` folder in the repo, with all the relevant commands, see other pact-foundation repos, if you are unsure.
+
+For your particular repo, check the following
+
+- `./github/workflows` folder for github action jobs
+- `.cirrus.yml` workflow for cirrus-ci jobs
+
+### Tested Platforms
+
+- Windows
+- MacOS
+- Linux
+
+### Tested Architectures
+
+- x86_64 / x64
+- arm64 / aarch64
+
+### CI Systems
+
+We utilize a combination of
+
+- GitHub Actions
+  - Windows x86_64
+  - MacOS x86_64
+  - Linux x86_64 / amd64
+- Cirrus-CI
+  - MacOS arm64
+  - MacOS x86_64 emulation via Rosetta
+  - Linux arm64
+  - Linux x86_64 / amd64
+
+### CI Testing Table
+
+This is a CI testing table for `pact-ruby-standalone` - You should aim to try and cover as many as possible.
+
+| OS     | Standalone Version     | Architecture | Tested |
+| -------| ------- | ------------ | --------- |
+| OSX    | v2.0.0     | x86_64       | GitHub Actions            |
+| OSX    | v2.0.0     | aarch64 (arm)| Cirrus CI         |
+| Linux  | v2.0.0  | x86_64       | GitHub Actions          |
+| Linux  | v2.0.0  | aarch64 (arm)| Cirrus-CI       |
+| Windows| v2.0.0 | x86_64       | GitHub Actions        |
+| Windows| v2.0.0 | x86       | Untested        |
+| Windows| v2.0.0 | aarch64 (via x86 emulation) |  Untested       |
+
+### Running as the CI system locally
+
+You should be able to run the steps shown in the CI workflows, from your local machine, however there are some additional options available to you
+
+> "Think globally, act locally"
+
+There are a couple of ways, you can act as the CI system locally.
+
+- GitHub Actions
+  - [Act](https://github.com/nektos/act) (all hosts)
+- Cirrus-CI
+  - [Cirrus-cli](https://github.com/cirruslabs/cirrus-cli) (all hosts)
+  - [Tart.run](https://github.com/cirruslabs/tart/) (macOS hosts)
+
+These will provide you the ability to run the following combinations.
+
+| OS     | CI System        | Architecture  | Tool  | Notes |
+| Linux  | GitHub Actions   | x86_64        | act   | requires docker |
+| Linux  | Cirrus CI        | x86_64        | cirrus-cli   | requires docker or podman and x86_64 host |
+| Linux  | Cirrus CI        | aarch64       | cirrus-cli    | requires docker or podman and aarch64 host |
+| macOS  | Cirrus CI        | aarch64       | cirrus-cli / tart.run   | requires MacOS arm64 (M1/M2) host, can test with or without rosetta |
+
+#### Act notes
+
+In any repo with a `.github/workflows/*.yml` file in, you can run
+
+##### Running all the tasks
+
+`act`
+
+##### Reporters
+
+Reporting is pretty good out the box, if a little noisy, especially when running multi-matrix ubuntu tasks
+
+##### Running a single workflow
+
+`act -W .github/workflows/x-plat.yml`
+
+##### Running a single job
+
+`act -W --job build_linux`
+
+##### Passing in custom env vars
+
+##### Passing in secrets
+
+`act -s DOCKER_HUB_USERNAME=pactfoundation -s DOCKER_HUB_TOKEN=i<3Pact`
+
+##### Using docker-compose inside a workflow
+
+The base act image, doesn't have docker-compose in it, you can install it conditionally, using this [action](https://github.com/KengoTODA/actions-setup-docker-compose) 
+
+    ```yaml
+        - uses: KengoTODA/actions-setup-docker-compose@v1
+            if: ${{ env.ACT }}
+            name: Install `docker-compose` for use with https://github.com/nektos/act
+            with:
+            version: '2.15.1'
+    ```
+
+##### Gotchas
+
+1. non `x86_64` / `amd64` hosts will need to pass the `--container-architecture linux/amd64` flag when running `act`
+2. sometimes you get zombie containers that need killing.
+3. not everything works, so sometimes it justs worth pushing the code to CI
+
+#### Cirrus CLI notes
+
+See https://github.com/cirruslabs/cirrus-cli for instructions on how to download the tool
+
+_Note:_ Cirrus CLI only supports Linux container and macos_instance VMs at the moment.
+
+In any repo with a `.cirrus.yml` file in, you can run
+
+##### Running all the tasks
+
+`cirrus run`
+
+##### Reporters
+
+By default, you are shown `stdout` but it is swallowed as each step passes. I would recommend using the `--output github-actions` command
+
+`cirrus run --output github-actions`
+
+##### Running a single task
+
+`cirrus run "linux_arm64" --output github-actions`
+
+##### Passing in custom env vars
+
+`cirrus run "builder_ruby_source_linux" --output github-actions -e CIRRUS_CHANGE_TITLE="ci(cirrus): builder_ruby_source_linux"`
+
+##### Load a dockerfile as an environment
+
+_Note:_ Linux runners support the Dockerfile as a CI environment feature.
+
+ https://cirrus-ci.org/guide/docker-builder-vm/#dockerfile-as-a-ci-environme
+
+    ```yaml
+        alpine_arm64_task: 
+            arm_container:
+                dockerfile: Dockerfile.alpine.arm64
+                <<: *DOCKER_ARGS_ARM64_TEMPLATE
+            <<: *TEST_TASK_TEMPLATE
+    ```
+
+##### Placeholders / Templating
+
+We want to avoid repeating ourselves in our scripts, so we can use templates. Based on the `dockerfile` as an environment scenario above.
+
+This allows us to reuse our tasks across cirrus-ci, and ideally run the same scripts in both GitHub Actions and Cirrus-CI, remembering our golden rule
+
+> The workflow files should just contain code that wires the CI platform into your own scripts.
+
+        ```yaml
+        env:
+        PACT_VERSION: 2.0.0
+
+        TEST_TASK_TEMPLATE: &TEST_TASK_TEMPLATE
+        test_script: uname -a && pact-mock-service --help
+
+        DOCKER_ARGS_ARM64_TEMPLATE: &DOCKER_ARGS_ARM64_TEMPLATE
+            docker_arguments:
+            PACT_VERSION: $PACT_VERSION
+            TARGET_ARCH: arm64
+
+        DOCKER_ARGS_X64_TEMPLATE: &DOCKER_ARGS_X64_TEMPLATE
+            docker_arguments:
+            PACT_VERSION: $PACT_VERSION
+            TARGET_ARCH: x86_64
+        ```
+
+##### Gotchas
+
+1. cirrus cli ignores the `arm_container` task, and expects `container` which are setup in cirrus-ci to become `amd64`/`x86_64` hosts.
+   1. If you change `arm_container` to `container`, you can run the task on a macOS arm64 host, but the docker default platform will be `arm64`/`aarch64` which means you might not get the results you are expecting.
+   2. There are settings to configure, but these don't appear to work for me, or I haven't found the right combo yet.
+      1. `CIRRUS_ARCH` as an `env` var (https://cirrus-ci.org/guide/docker-builder-vm/#docker-builder-vm)
+      2. `architecture` as a `container` property (https://cirrus-ci.org/guide/docker-builder-vm/#under-the-hood)
+2. You'll need at least 50gb to 100gb to run macOS instance tests locally, as they pull down a ventura virtual machine
+3. If you get stuck on the steps for CI, you can boot a virtual macOS or linux machine, perform all the steps you need, test them out, then script them up

--- a/Dockerfile.alpine.arm64
+++ b/Dockerfile.alpine.arm64
@@ -6,12 +6,8 @@ ARG TARGET_ARCH
 ARG PACT_VERSION
 ARG TARGET_ARCH=${TARGET_ARCH:-arm64}
 ARG PACT_VERSION=${PACT_VERSION:-2.0.0}
-ENV GLIBC_VERSION=2.35-r0
 
-RUN apk --no-cache add gcompat libc6-compat bash libgcc libstdc++ \
-     && wget -O /etc/apk/keys/sgerrand.rsa.pub -q https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub \
-     && wget -q https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/glibc-${GLIBC_VERSION}.apk \
-     && apk --no-cache --force-overwrite add glibc-${GLIBC_VERSION}.apk
+RUN apk --no-cache add gcompat libc6-compat bash
 
 RUN wget -q https://github.com/pact-foundation/pact-ruby-standalone/releases/download/v${PACT_VERSION}/pact-${PACT_VERSION}-linux-${TARGET_ARCH}.tar.gz \
      && tar xzf pact-${PACT_VERSION}-linux-${TARGET_ARCH}.tar.gz \

--- a/Dockerfile.alpine.arm64
+++ b/Dockerfile.alpine.arm64
@@ -6,8 +6,13 @@ ARG TARGET_ARCH
 ARG PACT_VERSION
 ARG TARGET_ARCH=${TARGET_ARCH:-arm64}
 ARG PACT_VERSION=${PACT_VERSION:-2.0.0}
+ENV GLIBC_VERSION=2.35-r0
 
-RUN apk --no-cache add gcompat libc6-compat bash
+RUN apk --no-cache add gcompat libc6-compat bash libgcc libstdc++ \
+     && wget -O /etc/apk/keys/sgerrand.rsa.pub -q https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub \
+     && wget -q https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/glibc-${GLIBC_VERSION}.apk \
+     && apk --no-cache --force-overwrite add glibc-${GLIBC_VERSION}.apk
+
 RUN wget -q https://github.com/pact-foundation/pact-ruby-standalone/releases/download/v${PACT_VERSION}/pact-${PACT_VERSION}-linux-${TARGET_ARCH}.tar.gz \
      && tar xzf pact-${PACT_VERSION}-linux-${TARGET_ARCH}.tar.gz \
      && rm -rf pact-${PACT_VERSION}-linux-${TARGET_ARCH}.tar.gz \

--- a/Dockerfile.alpine.arm64
+++ b/Dockerfile.alpine.arm64
@@ -1,0 +1,16 @@
+FROM arm64v8/alpine
+
+WORKDIR ../
+
+ARG TARGET_ARCH
+ARG PACT_VERSION
+ARG TARGET_ARCH=${TARGET_ARCH:-arm64}
+ARG PACT_VERSION=${PACT_VERSION:-2.0.0}
+
+RUN apk --no-cache add gcompat libc6-compat bash
+RUN wget -q https://github.com/pact-foundation/pact-ruby-standalone/releases/download/v${PACT_VERSION}/pact-${PACT_VERSION}-linux-${TARGET_ARCH}.tar.gz \
+     && tar xzf pact-${PACT_VERSION}-linux-${TARGET_ARCH}.tar.gz \
+     && rm -rf pact-${PACT_VERSION}-linux-${TARGET_ARCH}.tar.gz \
+     && ln -s /pact/bin/* /usr/local/bin
+
+ENTRYPOINT ["pact-mock-service"]

--- a/Dockerfile.alpine.x64
+++ b/Dockerfile.alpine.x64
@@ -1,0 +1,16 @@
+FROM alpine:latest
+
+WORKDIR ../
+
+ARG TARGET_ARCH
+ARG PACT_VERSION
+ARG TARGET_ARCH=${TARGET_ARCH:-arm64}
+ARG PACT_VERSION=${PACT_VERSION:-2.0.0}
+
+RUN apk --no-cache add gcompat libc6-compat bash
+RUN wget -q https://github.com/pact-foundation/pact-ruby-standalone/releases/download/v${PACT_VERSION}/pact-${PACT_VERSION}-linux-${TARGET_ARCH}.tar.gz \
+     && tar xzf pact-${PACT_VERSION}-linux-${TARGET_ARCH}.tar.gz \
+     && rm -rf pact-${PACT_VERSION}-linux-${TARGET_ARCH}.tar.gz \
+     && ln -s /pact/bin/* /usr/local/bin
+
+ENTRYPOINT ["pact-mock-service"]

--- a/Dockerfile.debian.slim
+++ b/Dockerfile.debian.slim
@@ -1,0 +1,16 @@
+FROM debian:11-slim
+
+WORKDIR ../
+
+ARG TARGET_ARCH
+ARG PACT_VERSION
+ARG TARGET_ARCH=${TARGET_ARCH:-arm64}
+ARG PACT_VERSION=${PACT_VERSION:-2.0.0}
+
+RUN apt update --yes && apt install wget --yes
+RUN wget -q https://github.com/pact-foundation/pact-ruby-standalone/releases/download/v${PACT_VERSION}/pact-${PACT_VERSION}-linux-${TARGET_ARCH}.tar.gz \
+     && tar xzf pact-${PACT_VERSION}-linux-${TARGET_ARCH}.tar.gz \
+     && rm -rf pact-${PACT_VERSION}-linux-${TARGET_ARCH}.tar.gz \
+     && ln -s /pact/bin/* /usr/local/bin
+
+ENTRYPOINT ["pact-mock-service"]

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -1,0 +1,16 @@
+FROM ubuntu:latest
+
+WORKDIR ../
+
+ARG TARGET_ARCH
+ARG PACT_VERSION
+ARG TARGET_ARCH=${TARGET_ARCH:-arm64}
+ARG PACT_VERSION=${PACT_VERSION:-2.0.0}
+
+RUN apt update --yes && apt install wget --yes
+RUN wget -q https://github.com/pact-foundation/pact-ruby-standalone/releases/download/v${PACT_VERSION}/pact-${PACT_VERSION}-linux-${TARGET_ARCH}.tar.gz \
+     && tar xzf pact-${PACT_VERSION}-linux-${TARGET_ARCH}.tar.gz \
+     && rm -rf pact-${PACT_VERSION}-linux-${TARGET_ARCH}.tar.gz \
+     && ln -s /pact/bin/* /usr/local/bin
+
+ENTRYPOINT ["pact-mock-service"]

--- a/packaging/pact-broker.sh
+++ b/packaging/pact-broker.sh
@@ -22,6 +22,7 @@ LIBDIR="`cd \"$DIR\" && cd ../lib && pwd`"
 export BUNDLE_GEMFILE="$LIBDIR/vendor/Gemfile"
 unset BUNDLE_IGNORE_CONFIG
 unset RUBYGEMS_GEMDEPS
+unset BUNDLE_APP_CONFIG
 export BUNDLE_FROZEN=1
 
 # Run the actual app using the bundled Ruby interpreter, with Bundler activated.

--- a/packaging/pact-message.sh
+++ b/packaging/pact-message.sh
@@ -22,6 +22,7 @@ LIBDIR="`cd \"$DIR\" && cd ../lib && pwd`"
 export BUNDLE_GEMFILE="$LIBDIR/vendor/Gemfile"
 unset BUNDLE_IGNORE_CONFIG
 unset RUBYGEMS_GEMDEPS
+unset BUNDLE_APP_CONFIG
 export BUNDLE_FROZEN=1
 
 # Run the actual app using the bundled Ruby interpreter, with Bundler activated.

--- a/packaging/pact-mock-service.sh
+++ b/packaging/pact-mock-service.sh
@@ -22,6 +22,7 @@ LIBDIR="`cd \"$DIR\" && cd ../lib && pwd`"
 export BUNDLE_GEMFILE="$LIBDIR/vendor/Gemfile"
 unset BUNDLE_IGNORE_CONFIG
 unset RUBYGEMS_GEMDEPS
+unset BUNDLE_APP_CONFIG
 export BUNDLE_FROZEN=1
 
 # Run the actual app using the bundled Ruby interpreter, with Bundler activated.

--- a/packaging/pact-provider-verifier.sh
+++ b/packaging/pact-provider-verifier.sh
@@ -22,6 +22,7 @@ LIBDIR="`cd \"$DIR\" && cd ../lib && pwd`"
 export BUNDLE_GEMFILE="$LIBDIR/vendor/Gemfile"
 unset BUNDLE_IGNORE_CONFIG
 unset RUBYGEMS_GEMDEPS
+unset BUNDLE_APP_CONFIG
 export BUNDLE_FROZEN=1
 
 # Run the actual app using the bundled Ruby interpreter, with Bundler activated.

--- a/packaging/pact-publish.sh
+++ b/packaging/pact-publish.sh
@@ -22,6 +22,7 @@ LIBDIR="`cd \"$DIR\" && cd ../lib && pwd`"
 export BUNDLE_GEMFILE="$LIBDIR/vendor/Gemfile"
 unset BUNDLE_IGNORE_CONFIG
 unset RUBYGEMS_GEMDEPS
+unset BUNDLE_APP_CONFIG
 export BUNDLE_FROZEN=1
 
 # Run the actual app using the bundled Ruby interpreter, with Bundler activated.

--- a/packaging/pact-stub-service.sh
+++ b/packaging/pact-stub-service.sh
@@ -22,6 +22,7 @@ LIBDIR="`cd \"$DIR\" && cd ../lib && pwd`"
 export BUNDLE_GEMFILE="$LIBDIR/vendor/Gemfile"
 unset BUNDLE_IGNORE_CONFIG
 unset RUBYGEMS_GEMDEPS
+unset BUNDLE_APP_CONFIG
 export BUNDLE_FROZEN=1
 
 # Run the actual app using the bundled Ruby interpreter, with Bundler activated.

--- a/packaging/pact.sh
+++ b/packaging/pact.sh
@@ -22,6 +22,7 @@ LIBDIR="`cd \"$DIR\" && cd ../lib && pwd`"
 export BUNDLE_GEMFILE="$LIBDIR/vendor/Gemfile"
 unset BUNDLE_IGNORE_CONFIG
 unset RUBYGEMS_GEMDEPS
+unset BUNDLE_APP_CONFIG
 export BUNDLE_FROZEN=1
 
 # Run the actual app using the bundled Ruby interpreter, with Bundler activated.

--- a/packaging/pactflow.sh
+++ b/packaging/pactflow.sh
@@ -22,6 +22,7 @@ LIBDIR="`cd \"$DIR\" && cd ../lib && pwd`"
 export BUNDLE_GEMFILE="$LIBDIR/vendor/Gemfile"
 unset BUNDLE_IGNORE_CONFIG
 unset RUBYGEMS_GEMDEPS
+unset BUNDLE_APP_CONFIG
 export BUNDLE_FROZEN=1
 
 # Run the actual app using the bundled Ruby interpreter, with Bundler activated.

--- a/script/unpack-and-test.sh
+++ b/script/unpack-and-test.sh
@@ -41,6 +41,14 @@ if [ "$BINARY_OS" == "" ] || [ "$BINARY_ARCH" == "" ] ; then
 fi
 
 
+cd pkg
+rm -rf pact
+ls
+
+if [ "$BINARY_OS" != "windows" ]; then tar xvf *$BINARY_OS-$BINARY_ARCH.tar.gz; else unzip *$BINARY_OS-$BINARY_ARCH.zip; fi
+if [ "$BINARY_OS" != "windows" ] ; then PATH_SEPERATOR=/ ; else PATH_SEPERATOR=\\; fi
+PATH_TO_BIN=.${PATH_SEPERATOR}pact${PATH_SEPERATOR}bin${PATH_SEPERATOR}
+
 tools=(
   # pact 
   pact-broker
@@ -56,8 +64,8 @@ for tool in ${tools[@]}; do
   echo testing $tool
   if [ "$BINARY_OS" != "windows" ] ; then echo "no bat file ext needed for $(uname -a)" ; else FILE_EXT=.bat; fi
   if [ "$BINARY_OS" = "windows" ] && [ "$tool" = "pact-plugin-cli" ] ; then  FILE_EXT=.exe ; else echo "no exe file ext needed for $(uname -a)"; fi
-  echo executing ${tool}${FILE_EXT} 
-  if [ "$BINARY_ARCH" = "x86" ] && [ "$tool" = "pact-plugin-cli" ] ; then  echo "skipping for x86" ; else ${tool}${FILE_EXT} --help; fi
+  echo executing ${PATH_TO_BIN}${tool}${FILE_EXT} 
+  if [ "$BINARY_ARCH" = "x86" ] && [ "$tool" = "pact-plugin-cli" ] ; then  echo "skipping for x86" ; else ${PATH_TO_BIN}${tool}${FILE_EXT} --help; fi
 done
 
 


### PR DESCRIPTION
There was a reported issue for a user, with an unknown container type, with regards to messaging for

`require': libyaml-0.so.2: cannot open shared object file: No such file or directory - /tmp/cirrus-ci-build/standalone/linux-x64-2.0.0/pact/lib/ruby/lib/ruby/3.2.0/x86_64-linux/psych.so`

This was seen in a pact-js-core test run, consuming the new 2.0.0 package

https://cirrus-ci.com/build/5720119662346240

Full output

```console

<internal:/tmp/cirrus-ci-build/standalone/linux-x64-2.0.0/pact/lib/ruby/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:37:in `require': libyaml-0.so.2: cannot open shared object file: No such file or directory - /tmp/cirrus-ci-build/standalone/linux-x64-2.0.0/pact/lib/ruby/lib/ruby/3.2.0/x86_64-linux/psych.so (LoadError)
	from <internal:/tmp/cirrus-ci-build/standalone/linux-x64-2.0.0/pact/lib/ruby/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
	from /tmp/cirrus-ci-build/standalone/linux-x64-2.0.0/pact/lib/ruby/lib/ruby/3.2.0/psych.rb:13:in `<top (required)>'
	from <internal:/tmp/cirrus-ci-build/standalone/linux-x64-2.0.0/pact/lib/ruby/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
	from <internal:/tmp/cirrus-ci-build/standalone/linux-x64-2.0.0/pact/lib/ruby/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
	from /tmp/cirrus-ci-build/standalone/linux-x64-2.0.0/pact/lib/ruby/lib/ruby/3.2.0/yaml.rb:4:in `<top (required)>'
	from <internal:/tmp/cirrus-ci-build/standalone/linux-x64-2.0.0/pact/lib/ruby/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
	from <internal:/tmp/cirrus-ci-build/standalone/linux-x64-2.0.0/pact/lib/ruby/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
	from /tmp/cirrus-ci-build/standalone/linux-x64-2.0.0/pact/lib/vendor/ruby/3.2.0/gems/pact_broker-client-1.66.1/lib/pact_broker/client/describe_text_formatter.rb:1:in `<top (required)>'
	from <internal:/tmp/cirrus-ci-build/standalone/linux-x64-2.0.0/pact/lib/ruby/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
	from <internal:/tmp/cirrus-ci-build/standalone/linux-x64-2.0.0/pact/lib/ruby/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
	from /tmp/cirrus-ci-build/standalone/linux-x64-2.0.0/pact/lib/vendor/ruby/3.2.0/gems/pact_broker-client-1.66.1/lib/pact_broker/client/pacticipants/describe.rb:2:in `<top (required)>'
	from <internal:/tmp/cirrus-ci-build/standalone/linux-x64-2.0.0/pact/lib/ruby/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
	from <internal:/tmp/cirrus-ci-build/standalone/linux-x64-2.0.0/pact/lib/ruby/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
	from /tmp/cirrus-ci-build/standalone/linux-x64-2.0.0/pact/lib/vendor/ruby/3.2.0/gems/pact_broker-client-1.66.1/lib/pact_broker/client/pacticipants.rb:3:in `<top (required)>'
	from <internal:/tmp/cirrus-ci-build/standalone/linux-x64-2.0.0/pact/lib/ruby/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
	from <internal:/tmp/cirrus-ci-build/standalone/linux-x64-2.0.0/pact/lib/ruby/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
	from /tmp/cirrus-ci-build/standalone/linux-x64-2.0.0/pact/lib/vendor/ruby/3.2.0/gems/pact_broker-client-1.66.1/lib/pact_broker/client/pact_broker_client.rb:1:in `<top (required)>'
	from <internal:/tmp/cirrus-ci-build/standalone/linux-x64-2.0.0/pact/lib/ruby/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
	from <internal:/tmp/cirrus-ci-build/standalone/linux-x64-2.0.0/pact/lib/ruby/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
	from /tmp/cirrus-ci-build/standalone/linux-x64-2.0.0/pact/lib/vendor/ruby/3.2.0/gems/pact_broker-client-1.66.1/lib/pact_broker/client/can_i_deploy.rb:2:in `<top (required)>'
	from <internal:/tmp/cirrus-ci-build/standalone/linux-x64-2.0.0/pact/lib/ruby/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
	from <internal:/tmp/cirrus-ci-build/standalone/linux-x64-2.0.0/pact/lib/ruby/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
	from /tmp/cirrus-ci-build/standalone/linux-x64-2.0.0/pact/lib/vendor/ruby/3.2.0/gems/pact_broker-client-1.66.1/lib/pact_broker/client/cli/matrix_commands.rb:28:in `can_i_deploy'
	from /tmp/cirrus-ci-build/standalone/linux-x64-2.0.0/pact/lib/vendor/ruby/3.2.0/gems/thor-1.2.1/lib/thor/command.rb:27:in `run'
	from /tmp/cirrus-ci-build/standalone/linux-x64-2.0.0/pact/lib/vendor/ruby/3.2.0/gems/thor-1.2.1/lib/thor/invocation.rb:127:in `invoke_command'
	from /tmp/cirrus-ci-build/standalone/linux-x64-2.0.0/pact/lib/vendor/ruby/3.2.0/gems/thor-1.2.1/lib/thor.rb:392:in `dispatch'
	from /tmp/cirrus-ci-build/standalone/linux-x64-2.0.0/pact/lib/vendor/ruby/3.2.0/gems/thor-1.2.1/lib/thor/base.rb:485:in `start'
	from /tmp/cirrus-ci-build/standalone/linux-x64-2.0.0/pact/lib/vendor/ruby/3.2.0/gems/pact_broker-client-1.66.1/lib/pact_broker/client/cli/custom_thor.rb:23:in `start'
	from /tmp/cirrus-ci-build/standalone/linux-x64-2.0.0/pact/lib/app/pact-broker.rb:34:in `<main>'
```



`libyaml-dev` was then added

https://github.com/pact-foundation/pact-js-core/pull/445/commits/f4eb407e3fd3ea173f83bc919125e45423284c51

with a passing run after

![Screenshot 2023-05-03 at 16 25 53](https://user-images.githubusercontent.com/19932401/235963221-e51b3153-d6af-4658-8088-f75e81fb31ea.png)

I have tried to replicate with several container types here, but in ended up stumbling across #56 so that fix is applied here, along with various docker containers that are tested and free for users to lift and use.

Another issue was identified and raised as #102 

So I think the summation of this, is that we will need to put a troubleshooting note, or pre-req that linux users must have the libyaml package on their system (at this current moment) until I peek into the build system and see what (if anything) I borked, but if adding a small dependency works for users, it's probably hugest of concerns.

I stand to be corrected however, and am happy dropping the latest tag and moving `2.0.0` to a pre-release so it doens't get picked up with the latest install scripts.


Massively out of date ruby or install libyaml-dev 🤷🏾‍♂️ 