### PR TITLE
fix: Update install.sh to allow pinning of version

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,23 +1,46 @@
 #!/bin/bash -e
 #
-# Usage:
+# Usage: (install latest)
 #   $ curl -fsSL https://raw.githubusercontent.com/pact-foundation/pact-ruby-standalone/master/install.sh | bash
 # or
 #   $ wget -q https://raw.githubusercontent.com/pact-foundation/pact-ruby-standalone/master/install.sh -O- | bash
 #
+# Usage: (install fixed version)
+#   $ tag=v1.92.0 curl -fsSL https://raw.githubusercontent.com/pact-foundation/pact-ruby-standalone/master/install.sh | bash
+# or
+#   $ tag=v1.92.0 wget -q https://raw.githubusercontent.com/pact-foundation/pact-ruby-standalone/master/install.sh -O- | bash
+#
+
+if [[ -z $tag ]]; then
+  tag=$(basename $(curl -fs -o/dev/null -w %{redirect_url} https://github.com/pact-foundation/pact-ruby-standalone/releases/latest))
+fi
 
 case $(uname -sm) in
   'Linux x86_64')
     os='linux-x86_64'
     ;;
   'Linux aarch64')
-    os='linux-arm64'
+    if [[ "${tag#v}" < 2 ]]; then
+        echo "Sorry, you'll need to install the pact-ruby-standalone manually."
+        exit 1
+    else
+        os='linux-arm64'
+    fi
     ;;
   'Darwin arm64')
-    os='osx-arm64'
+    if [[ "${tag#v}" < 2 ]]; then
+        os='osx'
+    else
+        os='osx-arm64'
+    fi
     ;;
   'Darwin x86' | 'Darwin x86_64')
-    os='osx-x86_64'
+    if [[ "${tag#v}" < 2 ]]; then
+        os='osx'
+    else
+        os='osx-x86_64'
+    fi
+
     ;;
   *)
   echo "Sorry, you'll need to install the pact-ruby-standalone manually."
@@ -25,10 +48,8 @@ case $(uname -sm) in
     ;;
 esac
 
-tag=$(basename $(curl -fs -o/dev/null -w %{redirect_url} https://github.com/pact-foundation/pact-ruby-standalone/releases/latest))
-filename="pact-${tag#v}-${os}.tar.gz"
 
+filename="pact-${tag#v}-${os}.tar.gz"
 curl -LO https://github.com/pact-foundation/pact-ruby-standalone/releases/download/${tag}/${filename}
 tar xzf ${filename}
 rm ${filename}
-


### PR DESCRIPTION
we recommend users fix versions for CI systems to avoid breakages,  but our script always pulls the latest

https://github.com/pact-foundation/pact-go#installation-on-nix

this allows users to pin to a particular tag

`curl -fsSL https://raw.githubusercontent.com/pact-foundation/pact-ruby-standalone/fix/allow_fixed_versions_install_script/install.sh | tag=v1.92.0 bash`

and will work out the file name for them.

There has been a couple of reported errors with 2.0.0, so this is an extra measure users can apply.


```
example-consumer-golang on  master [✘!?⇣] via 🐹 v1.20.3 on ☁️  (eu-west-2) 
🕙21:32:24 ❯ curl -fsSL https://raw.githubusercontent.com/pact-foundation/pact-ruby-standalone/fix/allow_fixed_versions_install_script/install.sh | tag=v1.92.0 bash    
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 12.2M  100 12.2M    0     0  14.6M      0 --:--:-- --:--:-- --:--:--  116M

example-consumer-golang on  master [✘!?⇣] via 🐹 v1.20.3 on ☁️  (eu-west-2) 
🕙21:32:46 ❯ ./pact/bin/pact-mock-service 
INFO  WEBrick 1.3.1
INFO  ruby 2.4.10 (2020-03-31) [x86_64-darwin19]
INFO  WEBrick::HTTPServer#start: pid=19742 port=54025
^CINFO  going to shutdown ...
INFO  WEBrick::HTTPServer#start done.

example-consumer-golang on  master [✘!?⇣] via 🐹 v1.20.3 on ☁️  (eu-west-2) took 3s 
🕙21:32:51 ❯ ./pact/bin/pact-mock-service 

example-consumer-golang on  master [✘!?⇣] via 🐹 v1.20.3 on ☁️  (eu-west-2) 
🕙21:32:54 [🧱 INT] ❯curl -fsSL https://raw.githubusercontent.com/pact-foundation/pact-ruby-standalone/fix/allow_fixed_versions_install_script/install.sh | tag=v2.0.0 bash  
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 19.4M  100 19.4M    0     0  13.0M      0  0:00:01  0:00:01 --:--:-- 31.0M

example-consumer-golang on  master [✘!?⇣] via 🐹 v1.20.3 on ☁️  (eu-west-2) took 2s 
🕙21:33:01 ❯ ./pact/bin/pact-mock-service 
INFO  WEBrick 1.8.1
INFO  ruby 3.2.2 (2023-03-30) [arm64-darwin22]
INFO  WEBrick::HTTPServer#start: pid=20195 port=54030
c^CINFO  going to shutdown ...
INFO  WEBrick::HTTPServer#start done.
```