### PR TITLE
chore(install): make installer verbose

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,26 +1,38 @@
 #!/bin/bash -e
-#
+## Tested with https://www.shellcheck.net/
 # Usage: (install latest)
-#   $ curl -fsSL https://raw.githubusercontent.com/pact-foundation/pact-ruby-standalone/master/install.sh | bash
+#   $ curl -fsSL https://raw.githubusercontent.com/pact-foundation/pact-ruby-standalone/master/install.sh | sh
 # or
-#   $ wget -q https://raw.githubusercontent.com/pact-foundation/pact-ruby-standalone/master/install.sh -O- | bash
+#   $ wget -q https://raw.githubusercontent.com/pact-foundation/pact-ruby-standalone/master/install.sh -O- | sh
 #
 # Usage: (install fixed version) - pass tag=v<tag> eg tag=v1.92.0 or set as an env var
-#   $ curl -fsSL https://raw.githubusercontent.com/pact-foundation/pact-ruby-standalone/master/install.sh | tag=v1.92.0 bash
+#   $ curl -fsSL https://raw.githubusercontent.com/pact-foundation/pact-ruby-standalone/master/install.sh | tag=v1.92.0 sh
 # or
-#   $ wget -q https://raw.githubusercontent.com/pact-foundation/pact-ruby-standalone/master/install.sh -O- | tag=v1.92.0 bash
+#   $ wget -q https://raw.githubusercontent.com/pact-foundation/pact-ruby-standalone/master/install.sh -O- | tag=v1.92.0 sh
 #
 
-if [[ -z $tag ]]; then
-  tag=$(basename $(curl -fs -o/dev/null -w %{redirect_url} https://github.com/pact-foundation/pact-ruby-standalone/releases/latest))
+if [[ -z "$tag" ]]; then
+  tag=$(basename "$(curl -fs -o/dev/null -w "%{redirect_url}" https://github.com/pact-foundation/pact-ruby-standalone/releases/latest)")
+  echo "Thanks for downloading the latest release of pact-ruby-standalone $tag."
+  echo "-----"
+  echo "Note:"
+  echo "-----"
+  echo "You can download a fixed version by setting the tag environment variable eg tag=v1.92.0"
+  echo "example:"
+  echo "curl -fsSL https://raw.githubusercontent.com/pact-foundation/pact-ruby-standalone/master/install.sh | tag=v1.92.0 sh"
+else
+  echo "Thanks for downloading pact-ruby-standalone $tag."
 fi
+
+TAG_WITHOUT_V=${tag#v}
+MAJOR_TAG=$(echo "$TAG_WITHOUT_V" | cut -d '.' -f 1)
 
 case $(uname -sm) in
   'Linux x86_64')
     os='linux-x86_64'
     ;;
   'Linux aarch64')
-    if [[ "${tag#v}" < 2 ]]; then
+    if [[ "$MAJOR_TAG" -lt 2 ]]; then
         echo "Sorry, you'll need to install the pact-ruby-standalone manually."
         exit 1
     else
@@ -28,14 +40,14 @@ case $(uname -sm) in
     fi
     ;;
   'Darwin arm64')
-    if [[ "${tag#v}" < 2 ]]; then
+    if [[ "$MAJOR_TAG" -lt 2 ]]; then
         os='osx'
     else
         os='osx-arm64'
     fi
     ;;
   'Darwin x86' | 'Darwin x86_64')
-    if [[ "${tag#v}" < 2 ]]; then
+    if [[ "$MAJOR_TAG" -lt 2 ]]; then
         os='osx'
     else
         os='osx-x86_64'
@@ -50,6 +62,14 @@ esac
 
 
 filename="pact-${tag#v}-${os}.tar.gz"
-curl -LO https://github.com/pact-foundation/pact-ruby-standalone/releases/download/${tag}/${filename}
-tar xzf ${filename}
-rm ${filename}
+echo "-------------"
+echo "Downloading:"
+echo "-------------"
+(curl -sLO https://github.com/pact-foundation/pact-ruby-standalone/releases/download/"${tag}"/"${filename}" && echo downloaded "${filename}") || (echo "Sorry, you'll need to install the pact-ruby-standalone manually." && exit 1)
+(tar xzf "${filename}" && echo unarchived "${filename}") || (echo "Sorry, you'll need to unarchived the pact-ruby-standalone manually." && exit 1)
+(rm "${filename}" && echo removed "${filename}") || (echo "Sorry, you'll need to remove the pact-ruby-standalone archive manually." && exit 1)
+echo "pact-ruby-standalone ${tag} installed to $(pwd)/pact"
+echo "-------------------"
+echo "available commands:"
+echo "-------------------"
+ls -1 "$(pwd)"/pact/bin


### PR DESCRIPTION
Provide a slicker experience for users when downloading via a script

1. Tell user if they aren't using a fixed version of a tag, that they can pin a version with the `tag` env var
2. Tell user if it fails to download, unarchive or remove the downloaded archive
3. Tell user path to where executables are installed
4. Show user available commands
5. Ensure script valid against https://www.shellcheck.net/

```console
 ❯ ./install.sh
Thanks for downloading the latest release of pact-ruby-standalone v1.92.0.
-----
Note:
-----
You can download a fixed version by setting the tag environment variable eg tag=v1.92.0
example:
curl -fsSL https://raw.githubusercontent.com/pact-foundation/pact-ruby-standalone/master/install.sh | tag=v1.92.0 sh
-------------
Downloading:
-------------
downloaded pact-1.92.0-osx.tar.gz
unarchived pact-1.92.0-osx.tar.gz
removed pact-1.92.0-osx.tar.gz
pact-ruby-standalone v1.92.0 installed to /Users/saf/dev/pact-foundation/pact-ruby-standalone/pact
-------------------
available commands:
-------------------
pact
pact-broker
pact-message
pact-mock-service
pact-plugin-cli
pact-provider-verifier
pact-publish
pact-stub-service
pactflow
```

```console
tag=v2.0.1 ./install.sh
Thanks for downloading pact-ruby-standalone v2.0.1.
-------------
Downloading:
-------------
downloaded pact-2.0.1-osx-arm64.tar.gz
unarchived pact-2.0.1-osx-arm64.tar.gz
removed pact-2.0.1-osx-arm64.tar.gz
pact-ruby-standalone v2.0.1 installed to /Users/saf/dev/pact-foundation/pact-ruby-standalone/pact
-------------------
available commands:
-------------------
pact
pact-broker
pact-message
pact-mock-service
pact-plugin-cli
pact-provider-verifier
pact-publish
pact-stub-service
pactflow
```

## Additional notes

1. Can be made `sh` compliant by
  - Changing `#!/bin/bash` to `#!/bin/sh`
  - Changing `[[ condition ]]` to `[ condition ]`