### PR TITLE
Chore/create dockerfiles

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,59 +1,223 @@
+env:
+  PACT_VERSION: 2.0.1
+  tag: v2.0.1
+
+#####################################
+###    BUILD & TEST STANDALONE    ###
+#####################################
+# This task packages up the pact-ruby-standalone for all arches
+# it is used in tasks
+# - builder_linux_arm_task
+# - builder_macos_arm_task
 BUILD_TEST_TASK_TEMPLATE: &BUILD_TEST_TASK_TEMPLATE
   arch_check_script:
     - uname -am
   install_script: bundle install
   build_script: bundle exec rake package
-  test_script: chmod +x ./script/test.sh && ./script/test.sh
-
-linux_arm64_task: 
+  test_script: chmod +x ./script/unpack-and-test.sh && ./script/unpack-and-test.sh
+# BINARY_ env vars are set, so we only test our platform specific pact-ruby-standalone
+builder_linux_arm_task: 
   env:
     BINARY_OS: linux
     BINARY_ARCH: arm64
     PATH: "$HOME/.rbenv/bin:/root/.rbenv/shims:$PATH"
-  ## *******************************  
-  ## Fails on Ruby:3.2.2 based image - fine on ubuntu latest, but installing ruby 3.2.2 from source takes a good while (few minutes)
-  ## executing ./pact/bin/pactflow
-  ## /tmp/cirrus-ci/working-dir/pkg/pact/lib/ruby/lib/ruby/3.2.0/bundler/definition.rb:524:in `materialize': Could not find pact-1.63.0, pact-message-0.11.1, pact-mock_service-3.11.0, pact-provider-verifier-1.36.1, pact_broker-client-1.66.1, webrick-1.8.1, rack-2.2.7, pact-support-1.19.0, rack-test-2.1.0, rspec-3.12.0, term-ansicolor-1.7.1, thor-1.2)
-  ##   from /tmp/cirrus-ci/working-dir/pkg/pact/lib/ruby/lib/ruby/3.2.0/bundler/definition.rb:197:in `specs'
-  ##   from /tmp/cirrus-ci/working-dir/pkg/pact/lib/ruby/lib/ruby/3.2.0/bundler/definition.rb:254:in `specs_for'
-  ##   from /tmp/cirrus-ci/working-dir/pkg/pact/lib/ruby/lib/ruby/3.2.0/bundler/runtime.rb:18:in `setup'
-  ##   from /tmp/cirrus-ci/working-dir/pkg/pact/lib/ruby/lib/ruby/3.2.0/bundler.rb:171:in `setup'
-  ##   from /tmp/cirrus-ci/working-dir/pkg/pact/lib/ruby/lib/ruby/3.2.0/bundler/setup.rb:23:in `block in <top (required)>'
-  ##   from /tmp/cirrus-ci/working-dir/pkg/pact/lib/ruby/lib/ruby/3.2.0/bundler/ui/shell.rb:159:in `with_level'
-  ##   from /tmp/cirrus-ci/working-dir/pkg/pact/lib/ruby/lib/ruby/3.2.0/bundler/ui/shell.rb:111:in `silence'
-  ##   from /tmp/cirrus-ci/working-dir/pkg/pact/lib/ruby/lib/ruby/3.2.0/bundler/setup.rb:23:in `<top (required)>'
-  ##   from <internal:/tmp/cirrus-ci/working-dir/pkg/pact/lib/ruby/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
-  ##   from <internal:/tmp/cirrus-ci/working-dir/pkg/pact/lib/ruby/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:85:in `require' 
-  ## *******************************  
-  # container:
-  #   image: ruby:3.2.2
-  #   architecture: arm64
-  # pre_req_script: |
-  #     apt update --yes && apt install --yes git curl libssl-dev libreadline-dev zlib1g-dev autoconf bison build-essential libyaml-dev libreadline-dev libncurses5-dev libffi-dev libgdbm-dev zip
-  #     ruby --version
-  #     bundler --version
   arm_container:
-    image: ubuntu:latest
-    architecture: arm64  
-  install_ruby_from_source_script: |
-      apt update --yes && apt install --yes git curl libssl-dev libreadline-dev zlib1g-dev autoconf bison build-essential libyaml-dev libreadline-dev libncurses5-dev libffi-dev libgdbm-dev zip
-      curl -fsSL https://github.com/rbenv/rbenv-installer/raw/HEAD/bin/rbenv-installer | bash
-      echo 'eval "$(rbenv init -)"' >> ~/.bashrc
-      source ~/.bashrc
-      rbenv install 3.2.2
-      rbenv global 3.2.2
-      ruby --version
-      bundler --version
+    image: ruby:3.2.2-slim
+  pre_req_script:
+      apt update --yes && apt install --yes zip curl
   << : *BUILD_TEST_TASK_TEMPLATE
-
-macosx_arm64_task: 
+  binary_artifacts:
+    path: "pkg/*"
+builder_macos_arm_task: 
   macos_instance:
     image: ghcr.io/cirruslabs/macos-ventura-base:latest
   env:
     BINARY_OS: osx
     BINARY_ARCH: arm64
-  pre_req_script: 
-    - brew install ruby
-    - ruby --version
+  ## If you need to install Ruby from source
+  ## the image comes with 3.2.2 preinstalled
+  # install_ruby_script: 
+  #   - |
+  #     brew unlink openssl && brew link --force openssl
+  #     wget https://cache.ruby-lang.org/pub/ruby/3.1/ruby-3.2.2.tar.gz
+  #     tar xf ruby-3.2.2.tar.gz
+  #     cd ruby-3.2.2
+  #     ./configure --prefix=/Users/$USER/.rbenv/versions/3.2.2
+  #     make -j9
+  #     make install
+  #   - rbenv global 3.2.2
+  ruby_version_script: ruby --version
   << : *BUILD_TEST_TASK_TEMPLATE
+  binary_artifacts:
+    path: "pkg/*"
 
+
+#####################################
+###  TESTING PUBLISHED STANDALONE ###
+#####################################
+
+# Tests a specified version of the standalone against several types of Docker images
+# the tag version is set at the top of file tag: v2.0.1
+# 
+# It tests a combination of Dockerfiles
+# The Dockerfiles are provided for users to build their own images
+#
+# - alpine arm64
+# - ubuntu arm64
+# - debian arm64
+# - alpine x64
+# - ubuntu x64
+# - debian x64
+
+# It also tests a combination of common Docker images
+# - IMAGE: ruby:3.2.2-alpine
+# - IMAGE: node:20-alpine
+# - IMAGE: golang:1.20.2-alpine
+# - IMAGE: ruby:3.2.2-slim
+# - IMAGE: node:20-slim
+# - IMAGE: golang:1.20.2
+
+## This is a yak shave relating to https://github.com/pact-foundation/pact-ruby-standalone/issues/102
+## pact-plugin-cli is not compatible with current guidance for alpine aarch64 with official arm64v8/alpine 
+## This task is reused in TEST_FULL_CLI_TASK_TEMPLATE adding in the pact-plugin-cli so its tested for other combos
+TEST_RUBY_CLI_TASK_TEMPLATE: &TEST_RUBY_CLI_TASK_TEMPLATE
+  arch_check_script:
+    - uname -am
+  test_script: | # would rather avoid the commands here, but also want to keep the images clean so they can be easily used by users
+      pact-broker help
+      pact-message help
+      pact-mock-service help
+      pact-provider-verifier help
+      pact-stub-service help
+      pactflow help
+
+TEST_FULL_CLI_TASK_TEMPLATE: &TEST_FULL_CLI_TASK_TEMPLATE
+  test_plugin_cli_script: pact-plugin-cli help
+  <<: *TEST_RUBY_CLI_TASK_TEMPLATE
+
+DOCKER_ARGS_ARM64_TEMPLATE: &DOCKER_ARGS_ARM64_TEMPLATE
+    docker_arguments:
+      PACT_VERSION: $PACT_VERSION
+      TARGET_ARCH: arm64
+      TARGET_PLATFORM: linux
+
+DOCKER_ARGS_X64_TEMPLATE: &DOCKER_ARGS_X64_TEMPLATE
+    docker_arguments:
+      PACT_VERSION: $PACT_VERSION
+      TARGET_ARCH: x86_64
+      TARGET_PLATFORM: linux
+
+## Test published standalone against arm64 Dockerfiles provided for users
+alpine_arm64_task:  
+  only_if: $CIRRUS_BRANCH == 'master' || $CIRRUS_PR
+  arm_container:
+    dockerfile: Dockerfile.alpine.arm64
+    <<: *DOCKER_ARGS_ARM64_TEMPLATE
+  <<: *TEST_RUBY_CLI_TASK_TEMPLATE
+ubuntu_arm64_task:  
+  only_if: $CIRRUS_BRANCH == 'master'
+  arm_container:
+    dockerfile: Dockerfile.ubuntu
+    <<: *DOCKER_ARGS_ARM64_TEMPLATE
+  <<: *TEST_RUBY_CLI_TASK_TEMPLATE
+debian_arm64_task:  
+  only_if: $CIRRUS_BRANCH == 'master'
+  arm_container:
+    dockerfile: Dockerfile.debian.slim
+    <<: *DOCKER_ARGS_ARM64_TEMPLATE
+  <<: *TEST_RUBY_CLI_TASK_TEMPLATE
+## Test published standalone against x64 Dockerfiles provided for users
+alpine_x64_task:  
+  only_if: $CIRRUS_BRANCH == 'master' || $CIRRUS_PR
+  container:
+    dockerfile: Dockerfile.alpine.x64
+    <<: *DOCKER_ARGS_X64_TEMPLATE
+  <<: *TEST_RUBY_CLI_TASK_TEMPLATE
+ubuntu_x64_task:  
+  only_if: $CIRRUS_BRANCH == 'master'
+  container:
+    dockerfile: Dockerfile.ubuntu
+    <<: *DOCKER_ARGS_X64_TEMPLATE
+  <<: *TEST_FULL_CLI_TASK_TEMPLATE
+debian_x64_task:  
+  only_if: $CIRRUS_BRANCH == 'master' || $CIRRUS_PR
+  container:
+    dockerfile: Dockerfile.debian.slim
+    <<: *DOCKER_ARGS_X64_TEMPLATE
+  <<: *TEST_FULL_CLI_TASK_TEMPLATE
+
+STANDALONE_INSTALL_TASK_TEMPLATE: &STANDALONE_INSTALL_TASK_TEMPLATE
+  install_script: |
+    curl -fsSL https://raw.githubusercontent.com/pact-foundation/pact-ruby-standalone/master/install.sh | bash \
+    && ln -s $PWD/pact/bin/* /usr/local/bin \
+    && ls pact/bin/ \
+    && ls /usr/local/bin
+## Test published standalone against common debian based images
+cli_test_debian_arm_task: 
+  only_if: $CIRRUS_BRANCH == 'master' || $CIRRUS_PR
+  env:
+    matrix:
+      - IMAGE: ruby:3.2.2-slim
+      - IMAGE: node:20-slim
+      - IMAGE: golang:1.20.2
+  arm_container:
+    image: $IMAGE
+    <<: *DOCKER_ARGS_ARM64_TEMPLATE
+  curl_script: apt update && apt install -y curl
+  <<: *STANDALONE_INSTALL_TASK_TEMPLATE
+  <<: *TEST_FULL_CLI_TASK_TEMPLATE
+
+## Test published standalone against common alpine based images
+cli_test_alpine_arm_task: 
+  only_if: $CIRRUS_BRANCH == 'master' || $CIRRUS_PR
+  env:
+    matrix:
+      - IMAGE: ruby:3.2.2-alpine
+      - IMAGE: node:20-alpine
+      - IMAGE: golang:1.20.2-alpine
+  arm_container:
+    image: $IMAGE
+    <<: *DOCKER_ARGS_ARM64_TEMPLATE
+  curl_script: apk add curl bash gcompat libc6-compat 
+  <<: *STANDALONE_INSTALL_TASK_TEMPLATE
+  <<: *TEST_RUBY_CLI_TASK_TEMPLATE
+
+## Test published standalone against common debian based images
+cli_test_debian_task: 
+  only_if: $CIRRUS_BRANCH == 'master' || $CIRRUS_PR
+  env:
+    matrix:
+      - IMAGE: ruby:3.2.2-slim
+      - IMAGE: node:20-slim
+      - IMAGE: golang:1.20.2
+  container:
+    image: $IMAGE
+    <<: *DOCKER_ARGS_ARM64_TEMPLATE
+  curl_script: apt update && apt install -y curl
+  <<: *STANDALONE_INSTALL_TASK_TEMPLATE
+  <<: *TEST_FULL_CLI_TASK_TEMPLATE
+
+## Test published standalone against common alpine based images
+cli_test_alpine_task: 
+  only_if: $CIRRUS_BRANCH == 'master' || $CIRRUS_PR
+  env:
+    matrix:
+      - IMAGE: ruby:3.2.2-alpine
+      - IMAGE: node:20-alpine
+      - IMAGE: golang:1.20.2-alpine
+  container:
+    image: $IMAGE
+    <<: *DOCKER_ARGS_ARM64_TEMPLATE
+  curl_script: apk add curl bash gcompat libc6-compat 
+  <<: *STANDALONE_INSTALL_TASK_TEMPLATE
+  <<: *TEST_RUBY_CLI_TASK_TEMPLATE
+
+
+## Test published standalone against MacOS arm64
+cli_test_macos_task: 
+  only_if: $CIRRUS_BRANCH == 'master' || $CIRRUS_PR
+  macos_instance:
+    image: ghcr.io/cirruslabs/macos-ventura-base:latest
+  setup_script: sudo mkdir -p /usr/local/bin && sudo chown -R `whoami` /usr/local/*
+  << : *STANDALONE_INSTALL_TASK_TEMPLATE
+  << : *TEST_FULL_CLI_TASK_TEMPLATE

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -109,7 +109,7 @@ DOCKER_ARGS_X64_TEMPLATE: &DOCKER_ARGS_X64_TEMPLATE
 
 ## Test published standalone against arm64 Dockerfiles provided for users
 alpine_arm64_task:  
-  only_if: $CIRRUS_BRANCH == 'master' || $CIRRUS_PR
+  only_if: $CIRRUS_BRANCH == 'master' || $CIRRUS_PR != ''
   arm_container:
     dockerfile: Dockerfile.alpine.arm64
     <<: *DOCKER_ARGS_ARM64_TEMPLATE
@@ -128,7 +128,7 @@ debian_arm64_task:
   <<: *TEST_RUBY_CLI_TASK_TEMPLATE
 ## Test published standalone against x64 Dockerfiles provided for users
 alpine_x64_task:  
-  only_if: $CIRRUS_BRANCH == 'master' || $CIRRUS_PR
+  only_if: $CIRRUS_BRANCH == 'master' || $CIRRUS_PR != ''
   container:
     dockerfile: Dockerfile.alpine.x64
     <<: *DOCKER_ARGS_X64_TEMPLATE
@@ -140,7 +140,7 @@ ubuntu_x64_task:
     <<: *DOCKER_ARGS_X64_TEMPLATE
   <<: *TEST_FULL_CLI_TASK_TEMPLATE
 debian_x64_task:  
-  only_if: $CIRRUS_BRANCH == 'master' || $CIRRUS_PR
+  only_if: $CIRRUS_BRANCH == 'master' || $CIRRUS_PR != ''
   container:
     dockerfile: Dockerfile.debian.slim
     <<: *DOCKER_ARGS_X64_TEMPLATE
@@ -154,7 +154,7 @@ STANDALONE_INSTALL_TASK_TEMPLATE: &STANDALONE_INSTALL_TASK_TEMPLATE
     && ls /usr/local/bin
 ## Test published standalone against common debian based images
 cli_test_debian_arm_task: 
-  only_if: $CIRRUS_BRANCH == 'master' || $CIRRUS_PR
+  only_if: $CIRRUS_BRANCH == 'master' || $CIRRUS_PR != ''
   env:
     matrix:
       - IMAGE: ruby:3.2.2-slim
@@ -169,7 +169,7 @@ cli_test_debian_arm_task:
 
 ## Test published standalone against common alpine based images
 cli_test_alpine_arm_task: 
-  only_if: $CIRRUS_BRANCH == 'master' || $CIRRUS_PR
+  only_if: $CIRRUS_BRANCH == 'master' || $CIRRUS_PR != ''
   env:
     matrix:
       - IMAGE: ruby:3.2.2-alpine
@@ -184,7 +184,7 @@ cli_test_alpine_arm_task:
 
 ## Test published standalone against common debian based images
 cli_test_debian_task: 
-  only_if: $CIRRUS_BRANCH == 'master' || $CIRRUS_PR
+  only_if: $CIRRUS_BRANCH == 'master' || $CIRRUS_PR != ''
   env:
     matrix:
       - IMAGE: ruby:3.2.2-slim
@@ -199,7 +199,7 @@ cli_test_debian_task:
 
 ## Test published standalone against common alpine based images
 cli_test_alpine_task: 
-  only_if: $CIRRUS_BRANCH == 'master' || $CIRRUS_PR
+  only_if: $CIRRUS_BRANCH == 'master' || $CIRRUS_PR != ''
   env:
     matrix:
       - IMAGE: ruby:3.2.2-alpine
@@ -215,7 +215,7 @@ cli_test_alpine_task:
 
 ## Test published standalone against MacOS arm64
 cli_test_macos_task: 
-  only_if: $CIRRUS_BRANCH == 'master' || $CIRRUS_PR
+  only_if: $CIRRUS_BRANCH == 'master' || $CIRRUS_PR != ''
   macos_instance:
     image: ghcr.io/cirruslabs/macos-ventura-base:latest
   setup_script: sudo mkdir -p /usr/local/bin && sudo chown -R `whoami` /usr/local/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,10 +40,10 @@ jobs:
     - name: Download all workflow run artifacts
       uses: actions/download-artifact@v3
     - name: test ${{ matrix.os }} package
-      run: ./script/test.sh
+      run: ./script/unpack-and-test.sh
     - name: test x86 package
       if: ${{ runner.os == 'Windows'}}
-      run: ./script/test.sh
+      run: ./script/unpack-and-test.sh
       env: 
         BINARY_OS: 'windows'
         BINARY_ARCH: 'x86'

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -1,0 +1,171 @@
+## Packaging
+
+pact-ruby-standalone is packaged with `traveling-ruby`
+
+### Building the `traveling-ruby` runtime
+
+1. Build the traveling ruby runtime
+   1. `git clone git@github.com:YOU54F/traveling-ruby.git`
+   2. `git checkout ci`
+
+For macOS - it will build for arm64 or x86_64 depending on your processor
+
+    cd osx
+    rake stash_conflicting_paths
+    rake --trace
+    rake unstash_conflicting_paths
+
+For macOS x86_64 on an m1 machine
+
+    sudo softwareupdate --install-rosetta --agree-to-license
+    cd osx
+    rake stash_conflicting_paths
+    arch -x86_64 rake --trace
+    rake unstash_conflicting_paths
+
+For Linux
+
+These are built via docker images, using [Phusions Holy Build Box](https://github.com/phusion/holy-build-box) so don't have to be built on a linux host. You can skip the `rake image` step, and it will pull from the image from Dockerhub
+
+For Linux x86_64
+
+    cd linux
+    ARCHITECTURES="x86_64" rake image
+    ARCHITECTURES="x86_64" rake
+
+For Linux arm64
+
+    cd linux
+    ARCHITECTURES="arm64" rake image
+    ARCHITECTURES="arm64" rake
+
+For Windows
+
+These dont package ruby gems, just the ruby runtime.
+
+Script is designed to run on Linux, but can be run on macOS or windows.
+
+1. macOS users will need `7zz` as an alias for `7z` - `brew install sevenzip`
+2. linux users will need `7z`
+3. windows users will need a `bash` shell, or prefix commands with `bash -c 'command'`
+   1. You'll also need to modify the commands below, for the necessary version
+   2. Happy to accept a PR to make it more powershell/cmd prompt friendly
+
+For windows x86_64
+
+    cd windows
+    bash -c 'mkdir -p cache output/3.2.2'
+    bash -c './build-ruby -a x86 -r 3.2.2 cache output/3.2.2'
+    bash -c './package -r traveling-ruby-20230428-3.2.2-x86-windows.tar.gz output/3.2.2'
+
+For windows x86
+
+    bash -c 'mkdir -p cache output/3.2.2'
+    bash -c './build-ruby -a x86_64 -r 3.2.2 cache output/3.2.2'
+    bash -c './package -r traveling-ruby-20230428-3.2.2-x86_64-windows.tar.gz output/3.2.2'
+
+### Building the pact-ruby-standalone packages
+
+The following steps are the same, whether you are using the published traveling-ruby binaries, or you have built your own
+
+Setup your gems
+
+    bundle install
+
+Build all the pact-ruby-standalone packages
+
+    bundle exec rake package
+
+Build only selected platforms
+
+    bundle exec rake package:linux:arm64
+    bundle exec rake package:linux:x64
+    bundle exec rake package:osx:arm64
+    bundle exec rake package:osx:x64
+    bundle exec rake package:windows:x64
+    bundle exec rake package:windows:x86
+
+#### Using your own built `traveling-ruby` packages
+
+1. in `tasks/package.rake`
+   1. comment out the `download_runtime` line, for whichever binary you don't want to want to download from the uploaded source but instead, use your own
+
+    ```ruby
+    file "build/traveling-ruby-#{TRAVELING_RUBY_VERSION}-linux-x86_64.tar.gz" do
+    # download_runtime(TRAVELING_RUBY_VERSION, "linux-x86_64")
+    end
+
+    file "build/traveling-ruby-#{TRAVELING_RUBY_VERSION}-linux-arm64.tar.gz" do
+    # download_runtime(TRAVELING_RUBY_VERSION, "linux-arm64")
+    end
+
+    file "build/traveling-ruby-#{TRAVELING_RUBY_VERSION}-osx-x86_64.tar.gz" do
+    # download_runtime(TRAVELING_RUBY_VERSION, "osx-x86_64")
+    end
+
+    file "build/traveling-ruby-#{TRAVELING_RUBY_VERSION}-osx-arm64.tar.gz" do
+    # download_runtime(TRAVELING_RUBY_VERSION, "osx-arm64")
+    end
+
+    file "build/traveling-ruby-#{TRAVELING_RUBY_VERSION}-windows-x86_64.tar.gz" do
+    # download_runtime(TRAVELING_RUBY_VERSION, "windows-x86_64")
+    end
+    file "build/traveling-ruby-#{TRAVELING_RUBY_VERSION}-windows-x86.tar.gz" do
+    # download_runtime(TRAVELING_RUBY_VERSION, "windows-x86")
+    end
+    ```
+
+2. Copy your built `traveling-ruby` package into the `build` folder
+3. Ensure the version number in `tasks/package.rake` matches your package name
+   1. eg
+      1. `traveling-ruby-20230508-3.2.2-linux-arm64.tar.gz`
+
+    ```ruby
+    TRAVELING_RUBY_VERSION = "20230508-3.2.2"
+    ```
+
+4. Run `bundle exec rake package` as before
+
+## Supported Platforms
+
+| OS     | Ruby      | Architecture | Supported |
+| -------| ------- | ------------ | --------- |
+| OSX    | 3.2.2     | x86_64       | ✅         |
+| OSX    | 3.2.2     | aarch64 (arm)| ✅         |
+| Linux  | 3.2.2   | x86_64       | ✅         |
+| Linux  | 3.2.2   | aarch64 (arm)| ✅          |
+| Windows| 3.2.2 | x86_64       | ✅        |
+| Windows| 3.2.2 | x86       | ✅        |
+| Windows| 3.2.2 | aarch64 (via x86 emulation) |  ✅        |
+
+## Testing
+
+We aim to support testing locally on all platforms, as well as using automated CI scripts.
+
+We suggest avoiding putting logic out of CI workflow yaml files and instead prefer shell files.
+
+We believe it makes testing locally so much easier.
+
+> The workflow files should just contain code that wires the CI platform into your own scripts.
+
+Because of this, you'll find a `script` folder in this repo, with all of the relevant commands.
+
+For the CI runs, check the following
+
+- `./github/workflows` folder for github action jobs
+- `.cirrus.yml` workflow for cirrus-ci jobs
+
+Github Actions is used to build, audit, test and push multi-arch images to DockerHub.
+
+Cirrus CI is used to build an arm64 image, and run the integration tests against it.
+
+### Running as the CI system locally
+
+You should be able to run the steps shown in the CI workflows, from your local machine.
+
+- GitHub Actions
+  - [Act](https://github.com/nektos/act) (all hosts)
+
+#### Run the test workflow
+
+`act --container-architecture linux/amd64 -W .github/workflows/build.yml --artifact-server-path tmp`

--- a/Dockerfile.alpine.arm64
+++ b/Dockerfile.alpine.arm64
@@ -1,0 +1,17 @@
+FROM arm64v8/alpine
+
+WORKDIR ../
+
+ARG TARGET_ARCH
+ARG PACT_VERSION
+ARG TARGET_ARCH=${TARGET_ARCH:-arm64}
+ARG PACT_VERSION=${PACT_VERSION:-2.0.1}
+
+RUN apk --no-cache add gcompat libc6-compat bash
+
+RUN wget -q https://github.com/pact-foundation/pact-ruby-standalone/releases/download/v${PACT_VERSION}/pact-${PACT_VERSION}-linux-${TARGET_ARCH}.tar.gz \
+     && tar xzf pact-${PACT_VERSION}-linux-${TARGET_ARCH}.tar.gz \
+     && rm -rf pact-${PACT_VERSION}-linux-${TARGET_ARCH}.tar.gz \
+     && ln -s /pact/bin/* /usr/local/bin
+
+ENTRYPOINT ["pact-mock-service"]

--- a/Dockerfile.alpine.x64
+++ b/Dockerfile.alpine.x64
@@ -1,0 +1,16 @@
+FROM alpine:latest
+
+WORKDIR ../
+
+ARG TARGET_ARCH
+ARG PACT_VERSION
+ARG TARGET_ARCH=${TARGET_ARCH:-arm64}
+ARG PACT_VERSION=${PACT_VERSION:-2.0.1}
+
+RUN apk --no-cache add gcompat libc6-compat bash
+RUN wget -q https://github.com/pact-foundation/pact-ruby-standalone/releases/download/v${PACT_VERSION}/pact-${PACT_VERSION}-linux-${TARGET_ARCH}.tar.gz \
+     && tar xzf pact-${PACT_VERSION}-linux-${TARGET_ARCH}.tar.gz \
+     && rm -rf pact-${PACT_VERSION}-linux-${TARGET_ARCH}.tar.gz \
+     && ln -s /pact/bin/* /usr/local/bin
+
+ENTRYPOINT ["pact-mock-service"]

--- a/Dockerfile.debian.slim
+++ b/Dockerfile.debian.slim
@@ -1,0 +1,16 @@
+FROM debian:11-slim
+
+WORKDIR ../
+
+ARG TARGET_ARCH
+ARG PACT_VERSION
+ARG TARGET_ARCH=${TARGET_ARCH:-arm64}
+ARG PACT_VERSION=${PACT_VERSION:-2.0.1}
+
+RUN apt update --yes && apt install wget --yes
+RUN wget -q https://github.com/pact-foundation/pact-ruby-standalone/releases/download/v${PACT_VERSION}/pact-${PACT_VERSION}-linux-${TARGET_ARCH}.tar.gz \
+     && tar xzf pact-${PACT_VERSION}-linux-${TARGET_ARCH}.tar.gz \
+     && rm -rf pact-${PACT_VERSION}-linux-${TARGET_ARCH}.tar.gz \
+     && ln -s /pact/bin/* /usr/local/bin
+
+ENTRYPOINT ["pact-mock-service"]

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -1,0 +1,16 @@
+FROM ubuntu:latest
+
+WORKDIR ../
+
+ARG TARGET_ARCH
+ARG PACT_VERSION
+ARG TARGET_ARCH=${TARGET_ARCH:-arm64}
+ARG PACT_VERSION=${PACT_VERSION:-2.0.1}
+
+RUN apt update --yes && apt install wget --yes
+RUN wget -q https://github.com/pact-foundation/pact-ruby-standalone/releases/download/v${PACT_VERSION}/pact-${PACT_VERSION}-linux-${TARGET_ARCH}.tar.gz \
+     && tar xzf pact-${PACT_VERSION}-linux-${TARGET_ARCH}.tar.gz \
+     && rm -rf pact-${PACT_VERSION}-linux-${TARGET_ARCH}.tar.gz \
+     && ln -s /pact/bin/* /usr/local/bin
+
+ENTRYPOINT ["pact-mock-service"]

--- a/script/unpack-and-test.sh
+++ b/script/unpack-and-test.sh
@@ -41,6 +41,14 @@ if [ "$BINARY_OS" == "" ] || [ "$BINARY_ARCH" == "" ] ; then
 fi
 
 
+cd pkg
+rm -rf pact
+ls
+
+if [ "$BINARY_OS" != "windows" ]; then tar xvf *$BINARY_OS-$BINARY_ARCH.tar.gz; else unzip *$BINARY_OS-$BINARY_ARCH.zip; fi
+if [ "$BINARY_OS" != "windows" ] ; then PATH_SEPERATOR=/ ; else PATH_SEPERATOR=\\; fi
+PATH_TO_BIN=.${PATH_SEPERATOR}pact${PATH_SEPERATOR}bin${PATH_SEPERATOR}
+
 tools=(
   # pact 
   pact-broker
@@ -56,8 +64,8 @@ for tool in ${tools[@]}; do
   echo testing $tool
   if [ "$BINARY_OS" != "windows" ] ; then echo "no bat file ext needed for $(uname -a)" ; else FILE_EXT=.bat; fi
   if [ "$BINARY_OS" = "windows" ] && [ "$tool" = "pact-plugin-cli" ] ; then  FILE_EXT=.exe ; else echo "no exe file ext needed for $(uname -a)"; fi
-  echo executing ${tool}${FILE_EXT} 
-  if [ "$BINARY_ARCH" = "x86" ] && [ "$tool" = "pact-plugin-cli" ] ; then  echo "skipping for x86" ; else ${tool}${FILE_EXT} help; fi
+  echo executing ${PATH_TO_BIN}${tool}${FILE_EXT} 
+  if [ "$BINARY_ARCH" = "x86" ] && [ "$tool" = "pact-plugin-cli" ] ; then  echo "skipping for x86" ; else ${PATH_TO_BIN}${tool}${FILE_EXT} help; fi
 done
 
 

--- a/tasks/package.rake
+++ b/tasks/package.rake
@@ -3,8 +3,7 @@ require 'bundler/setup'
 
 PACKAGE_NAME = "pact"
 VERSION = File.read('VERSION').strip
-TRAVELING_RUBY_VERSION_REL_DATE = "20230508"
-TRAVELING_RUBY_VERSION = "#{TRAVELING_RUBY_VERSION_REL_DATE}-3.2.2"
+TRAVELING_RUBY_VERSION = "20230508-3.2.2"
 PLUGIN_CLI_VERSION = "0.1.0"
 
 desc "Package pact-ruby-standalone for OSX, Linux x86_64 and windows x86_64"
@@ -54,17 +53,19 @@ namespace :package do
     sh "cp packaging/Gemfile packaging/Gemfile.lock build/tmp/"
     sh "mkdir -p build/tmp/lib/pact/mock_service"
     # sh "cp lib/pact/mock_service/version.rb build/tmp/lib/pact/mock_service/version.rb"
-    Bundler.with_unbundled_env do
-      sh "cd build/tmp && env BUNDLE_IGNORE_CONFIG=1 bundle lock --add-platform aarch64-linux x86_64-linux x86_64-darwin arm64-darwin x64-mingw-ucrt i386-mingw32 \
-                       && env BUNDLE_IGNORE_CONFIG=1 BUNDLE_DEPLOYMENT=true bundle install --path ../vendor"
+    Bundler.with_clean_env do
+      sh "cd build/tmp && env BUNDLE_IGNORE_CONFIG=1 bundle lock --add-platform x64-mingw32 && env BUNDLE_IGNORE_CONFIG=1 BUNDLE_DEPLOYMENT=true bundle install --path ../vendor"
       generate_readme
     end
     sh "rm -rf build/tmp"
     sh "rm -rf build/vendor/*/*/cache/*"
   end
-  
+
   task :generate_readme do
-    Bundler.with_unbundled_env do
+    Bundler.with_clean_env do
+      sh "mkdir -p build/tmp"
+      sh "cp packaging/Gemfile packaging/Gemfile.lock build/tmp/"
+      sh "cd build/tmp && env BUNDLE_IGNORE_CONFIG=1 bundle install --path ../vendor --without development"
       generate_readme
     end
   end
@@ -214,14 +215,14 @@ end
 def generate_readme
   template = File.absolute_path("packaging/README.md.template")
   script = File.absolute_path("packaging/generate_readme_contents.rb")
-  Bundler.with_unbundled_env do
+  Bundler.with_clean_env do
     sh "cd build/tmp && env VERSION=#{VERSION} bundle exec ruby #{script} #{template} > ../README.md"
   end
 end
 
 def download_runtime(version, target)
   sh "cd build && curl -L -O --fail " +
-    "https://github.com/YOU54F/traveling-ruby/releases/download/rel-#{TRAVELING_RUBY_VERSION_REL_DATE}/traveling-ruby-#{version}-#{target}.tar.gz"
+    "https://github.com/YOU54F/traveling-ruby/releases/download/rel-20230508/traveling-ruby-#{version}-#{target}.tar.gz"
 end
 
 def install_plugin_cli(package_dir, package_target)

--- a/tasks/package.rake
+++ b/tasks/package.rake
@@ -3,7 +3,8 @@ require 'bundler/setup'
 
 PACKAGE_NAME = "pact"
 VERSION = File.read('VERSION').strip
-TRAVELING_RUBY_VERSION = "20230508-3.2.2"
+TRAVELING_RUBY_VERSION_REL_DATE = "20230508"
+TRAVELING_RUBY_VERSION = "#{TRAVELING_RUBY_VERSION_REL_DATE}-3.2.2"
 PLUGIN_CLI_VERSION = "0.1.0"
 
 desc "Package pact-ruby-standalone for OSX, Linux x86_64 and windows x86_64"
@@ -53,19 +54,17 @@ namespace :package do
     sh "cp packaging/Gemfile packaging/Gemfile.lock build/tmp/"
     sh "mkdir -p build/tmp/lib/pact/mock_service"
     # sh "cp lib/pact/mock_service/version.rb build/tmp/lib/pact/mock_service/version.rb"
-    Bundler.with_clean_env do
-      sh "cd build/tmp && env BUNDLE_IGNORE_CONFIG=1 bundle lock --add-platform x64-mingw32 && env BUNDLE_IGNORE_CONFIG=1 BUNDLE_DEPLOYMENT=true bundle install --path ../vendor"
+    Bundler.with_unbundled_env do
+      sh "cd build/tmp && env BUNDLE_IGNORE_CONFIG=1 bundle lock --add-platform aarch64-linux x86_64-linux x86_64-darwin arm64-darwin x64-mingw-ucrt i386-mingw32 \
+                       && env BUNDLE_IGNORE_CONFIG=1 BUNDLE_DEPLOYMENT=true bundle install --path ../vendor"
       generate_readme
     end
     sh "rm -rf build/tmp"
     sh "rm -rf build/vendor/*/*/cache/*"
   end
-
+  
   task :generate_readme do
-    Bundler.with_clean_env do
-      sh "mkdir -p build/tmp"
-      sh "cp packaging/Gemfile packaging/Gemfile.lock build/tmp/"
-      sh "cd build/tmp && env BUNDLE_IGNORE_CONFIG=1 bundle install --path ../vendor --without development"
+    Bundler.with_unbundled_env do
       generate_readme
     end
   end
@@ -215,14 +214,14 @@ end
 def generate_readme
   template = File.absolute_path("packaging/README.md.template")
   script = File.absolute_path("packaging/generate_readme_contents.rb")
-  Bundler.with_clean_env do
+  Bundler.with_unbundled_env do
     sh "cd build/tmp && env VERSION=#{VERSION} bundle exec ruby #{script} #{template} > ../README.md"
   end
 end
 
 def download_runtime(version, target)
   sh "cd build && curl -L -O --fail " +
-    "https://github.com/YOU54F/traveling-ruby/releases/download/rel-20230508/traveling-ruby-#{version}-#{target}.tar.gz"
+    "https://github.com/YOU54F/traveling-ruby/releases/download/rel-#{TRAVELING_RUBY_VERSION_REL_DATE}/traveling-ruby-#{version}-#{target}.tar.gz"
 end
 
 def install_plugin_cli(package_dir, package_target)


### PR DESCRIPTION
This PR creates a suite of Dockerfiles of a few different flavours, namely Alpine, Debian and Ubuntu of arm64 and amd64 flavours, in which we test a tagged version of the pact-ruby-standalone against.

In a subsequent PR we will utilise the packaged standalone per build, in the containers, so we can ensure all the Dockerfiles provided to users are compatible with the latest release

It also utilises a Ruby image for the linux builder task in Cirrus CI to speed up the build cycle (vs building Ruby 3.2 for packaging, from source)