### PR TITLE
chore(rel): use tr_ruby rel-20230605 plus deprecated bundler command …

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,75 +1,121 @@
-#!/bin/bash -e
-## Tested with https://www.shellcheck.net/
+#!/bin/sh -e
+## Tested with https://www.shellcheck.net/
 # Usage: (install latest)
 #   $ curl -fsSL https://raw.githubusercontent.com/pact-foundation/pact-ruby-standalone/master/install.sh | sh
 # or
 #   $ wget -q https://raw.githubusercontent.com/pact-foundation/pact-ruby-standalone/master/install.sh -O- | sh
 #
-# Usage: (install fixed version) - pass tag=v<tag> eg tag=v1.92.0 or set as an env var
-#   $ curl -fsSL https://raw.githubusercontent.com/pact-foundation/pact-ruby-standalone/master/install.sh | tag=v1.92.0 sh
+# Usage: (install fixed version) - pass PACT_CLI_VERSION=v<PACT_CLI_VERSION> eg PACT_CLI_VERSION=v1.92.0 or set as an env var
+#   $ curl -fsSL https://raw.githubusercontent.com/pact-foundation/pact-ruby-standalone/master/install.sh | PACT_CLI_VERSION=v1.92.0 sh
 # or
-#   $ wget -q https://raw.githubusercontent.com/pact-foundation/pact-ruby-standalone/master/install.sh -O- | tag=v1.92.0 sh
+#   $ wget -q https://raw.githubusercontent.com/pact-foundation/pact-ruby-standalone/master/install.sh -O- | PACT_CLI_VERSION=v1.92.0 sh
 #
+if [ "$tag" ]; then
+  echo "setting $tag as PACT_CLI_VERSION for legacy reasons"
+  PACT_CLI_VERSION="$tag"
+fi
 
-if [[ -z "$tag" ]]; then
-  tag=$(basename "$(curl -fs -o/dev/null -w "%{redirect_url}" https://github.com/pact-foundation/pact-ruby-standalone/releases/latest)")
-  echo "Thanks for downloading the latest release of pact-ruby-standalone $tag."
+if [ -z "$PACT_CLI_VERSION" ]; then
+  PACT_CLI_VERSION=$(basename "$(curl -fs -o/dev/null -w "%{redirect_url}" https://github.com/pact-foundation/pact-ruby-standalone/releases/latest)")
+  echo "Thanks for downloading the latest release of pact-ruby-standalone $PACT_CLI_VERSION."
   echo "-----"
   echo "Note:"
   echo "-----"
-  echo "You can download a fixed version by setting the tag environment variable eg tag=v1.92.0"
+  echo "You can download a fixed version by setting the PACT_CLI_VERSION environment variable eg PACT_CLI_VERSION=v1.92.0"
   echo "example:"
-  echo "curl -fsSL https://raw.githubusercontent.com/pact-foundation/pact-ruby-standalone/master/install.sh | tag=v1.92.0 sh"
+  echo "curl -fsSL https://raw.githubusercontent.com/pact-foundation/pact-ruby-standalone/master/install.sh | PACT_CLI_VERSION=v1.92.0 sh"
 else
-  echo "Thanks for downloading pact-ruby-standalone $tag."
+  echo "Thanks for downloading pact-ruby-standalone $PACT_CLI_VERSION."
 fi
 
-TAG_WITHOUT_V=${tag#v}
-MAJOR_TAG=$(echo "$TAG_WITHOUT_V" | cut -d '.' -f 1)
+PACT_CLI_VERSION_WITHOUT_V=${PACT_CLI_VERSION#v}
+MAJOR_PACT_CLI_VERSION=$(echo "$PACT_CLI_VERSION_WITHOUT_V" | cut -d '.' -f 1)
 
 case $(uname -sm) in
-  'Linux x86_64')
-    os='linux-x86_64'
-    ;;
-  'Linux aarch64')
-    if [[ "$MAJOR_TAG" -lt 2 ]]; then
-        echo "Sorry, you'll need to install the pact-ruby-standalone manually."
-        exit 1
-    else
-        os='linux-arm64'
-    fi
-    ;;
-  'Darwin arm64')
-    if [[ "$MAJOR_TAG" -lt 2 ]]; then
-        os='osx'
-    else
-        os='osx-arm64'
-    fi
-    ;;
-  'Darwin x86' | 'Darwin x86_64')
-    if [[ "$MAJOR_TAG" -lt 2 ]]; then
-        os='osx'
-    else
-        os='osx-x86_64'
-    fi
-
-    ;;
-  *)
+'Linux x86_64')
+  os='linux-x86_64'
+  ;;
+'Linux aarch64')
+  if [ "$MAJOR_PACT_CLI_VERSION" -lt 2 ]; then
+    echo "Sorry, you'll need to install the pact-ruby-standalone manually."
+    exit 1
+  else
+    os='linux-arm64'
+  fi
+  ;;
+'Darwin arm64')
+  if [ "$MAJOR_PACT_CLI_VERSION" -lt 2 ]; then
+    os='osx'
+  else
+    os='osx-arm64'
+  fi
+  ;;
+'Darwin x86' | 'Darwin x86_64')
+  if [ "$MAJOR_PACT_CLI_VERSION" -lt 2 ]; then
+    os='osx'
+  else
+    os='osx-x86_64'
+  fi
+  ;;
+"Windows"* | "MINGW64"*)
+  if [ "$MAJOR_PACT_CLI_VERSION" -lt 2 ]; then
+    os='win32'
+  else
+    os='windows-x86_64'
+  fi
+  ;;
+*)
   echo "Sorry, you'll need to install the pact-ruby-standalone manually."
   exit 1
-    ;;
+  ;;
 esac
 
+case $os in
+'windows'* | 'win32')
+  filename="pact-${PACT_CLI_VERSION#v}-${os}.zip"
+  ;;
+'osx'* | 'linux'*)
+  filename="pact-${PACT_CLI_VERSION#v}-${os}.tar.gz"
+  ;;
+esac
 
-filename="pact-${tag#v}-${os}.tar.gz"
 echo "-------------"
 echo "Downloading:"
 echo "-------------"
-(curl -sLO https://github.com/pact-foundation/pact-ruby-standalone/releases/download/"${tag}"/"${filename}" && echo downloaded "${filename}") || (echo "Sorry, you'll need to install the pact-ruby-standalone manually." && exit 1)
-(tar xzf "${filename}" && echo unarchived "${filename}") || (echo "Sorry, you'll need to unarchived the pact-ruby-standalone manually." && exit 1)
+(curl -sLO https://github.com/pact-foundation/pact-ruby-standalone/releases/download/"${PACT_CLI_VERSION}"/"${filename}" && echo downloaded "${filename}") || (echo "Sorry, you'll need to install the pact-ruby-standalone manually." && exit 1)
+case $os in
+'windows'* | 'win32')
+  (unzip "${filename}" && echo unarchived "${filename}") || (echo "Sorry, you'll need to unarchived the pact-ruby-standalone manually." && exit 1)
+  ;;
+'osx'* | 'linux'*)
+  (tar xzf "${filename}" && echo unarchived "${filename}") || (echo "Sorry, you'll need to unarchived the pact-ruby-standalone manually." && exit 1)
+  ;;
+esac
 (rm "${filename}" && echo removed "${filename}") || (echo "Sorry, you'll need to remove the pact-ruby-standalone archive manually." && exit 1)
-echo "pact-ruby-standalone ${tag} installed to $(pwd)/pact"
+
+echo "pact-ruby-standalone ${PACT_CLI_VERSION} installed to $(pwd)/pact"
 echo "-------------------"
 echo "available commands:"
 echo "-------------------"
-ls -1 "$(pwd)"/pact/bin
+PROJECT_NAME=pact-cli
+PACT_CLI_BIN_PATH=${PWD}/pact/bin/
+
+ls -1 "$PACT_CLI_BIN_PATH"
+
+
+if [ "$GITHUB_ENV" ]; then
+echo "Added the following to your path to make ${PROJECT_NAME} available:"
+echo ""
+echo "PATH=$PACT_CLI_BIN_PATH:\${PATH}"
+echo "PATH=$PACT_CLI_BIN_PATH:${PATH}" >>"$GITHUB_ENV"
+elif [ "$CIRRUS_CI" ]; then
+echo "Added the following to your path to make ${PROJECT_NAME} available:"
+echo ""
+echo "PATH=$PACT_CLI_BIN_PATH:\${PATH}"
+echo "PATH=$PACT_CLI_BIN_PATH:${PATH}" >>"$CIRRUS_ENV"
+else
+echo "Add the following to your path to make ${PROJECT_NAME} available:"
+echo "--- Linux/MacOS/Windows Bash Users --------"
+echo ""
+echo "  PATH=:$PACT_CLI_BIN_PATH:\${PATH}"
+fi

--- a/tasks/package.rake
+++ b/tasks/package.rake
@@ -1,9 +1,10 @@
-# For Bundler.with_clean_env
+# For Bundler.with_unbundled_env
 require 'bundler/setup'
 
 PACKAGE_NAME = "pact"
 VERSION = File.read('VERSION').strip
-TRAVELING_RUBY_VERSION = "20230508-3.2.2"
+TRAVELING_RUBY_VERSION = "20230605-3.2.2"
+TRAVELING_RUBY_PKG_DATE = TRAVELING_RUBY_VERSION.split("-").first
 PLUGIN_CLI_VERSION = "0.1.0"
 
 desc "Package pact-ruby-standalone for OSX, Linux x86_64 and windows x86_64"
@@ -53,8 +54,8 @@ namespace :package do
     sh "cp packaging/Gemfile packaging/Gemfile.lock build/tmp/"
     sh "mkdir -p build/tmp/lib/pact/mock_service"
     # sh "cp lib/pact/mock_service/version.rb build/tmp/lib/pact/mock_service/version.rb"
-    Bundler.with_clean_env do
-      sh "cd build/tmp && env BUNDLE_IGNORE_CONFIG=1 bundle lock --add-platform x64-mingw32 && env BUNDLE_IGNORE_CONFIG=1 BUNDLE_DEPLOYMENT=true bundle install --path ../vendor"
+    Bundler.with_unbundled_env do
+      sh "cd build/tmp && env bundle lock --add-platform x64-mingw32 && bundle config set --local path '../vendor' && env BUNDLE_DEPLOYMENT=true bundle install"
       generate_readme
     end
     sh "rm -rf build/tmp"
@@ -62,7 +63,7 @@ namespace :package do
   end
 
   task :generate_readme do
-    Bundler.with_clean_env do
+    Bundler.with_unbundled_env do
       sh "mkdir -p build/tmp"
       sh "cp packaging/Gemfile packaging/Gemfile.lock build/tmp/"
       sh "cd build/tmp && env BUNDLE_IGNORE_CONFIG=1 bundle install --path ../vendor --without development"
@@ -215,14 +216,14 @@ end
 def generate_readme
   template = File.absolute_path("packaging/README.md.template")
   script = File.absolute_path("packaging/generate_readme_contents.rb")
-  Bundler.with_clean_env do
+  Bundler.with_unbundled_env do
     sh "cd build/tmp && env VERSION=#{VERSION} bundle exec ruby #{script} #{template} > ../README.md"
   end
 end
 
 def download_runtime(version, target)
   sh "cd build && curl -L -O --fail " +
-    "https://github.com/YOU54F/traveling-ruby/releases/download/rel-20230508/traveling-ruby-#{version}-#{target}.tar.gz"
+    "https://github.com/YOU54F/traveling-ruby/releases/download/rel-#{TRAVELING_RUBY_PKG_DATE}/traveling-ruby-#{version}-#{target}.tar.gz"
 end
 
 def install_plugin_cli(package_dir, package_target)


### PR DESCRIPTION
…with_unbundled_env

This change introduces various fixes in the traveling ruby build system

https://github.com/YOU54F/traveling-ruby/releases/tag/rel-20230605

most notable are

- reduction in size on the osx packages (duplicated `.a` binary)
- static linking complete on linux, `psych.so` was missing, but is now included in the bundle, and `libyaml` is no longer required by users to be installed on the host machine.
