### PR TITLE
fix(docs): correct windows filename to end in .zip in release notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,16 @@ Binaries will be extracted into `pact/bin`:
 └── pact-stub-service
 ```
 
+### Windows Users
+
+Please append `.bat` to any of the provided binaries
+
+eg.
+
+```ps1
+  .\pact\bin\pact-broker.bat
+```
+
 ## Installation
 
 See the [release page][releases].

--- a/packaging/README.md.template
+++ b/packaging/README.md.template
@@ -28,6 +28,16 @@ Binaries will be extracted into `pact/bin`:
 └── pact-stub-service
 ```
 
+### Windows Users
+
+Please append `.bat` to any of the provided binaries
+
+eg.
+
+```ps1
+  .\pact\bin\pact-broker.bat
+```
+
 ## Installation
 
 See the [release page][releases].

--- a/packaging/RELEASE_NOTES.md.template
+++ b/packaging/RELEASE_NOTES.md.template
@@ -47,14 +47,14 @@ tar xzf pact-<PACKAGE_VERSION>-linux-arm64.tar.gz
 #### x86_64
 
 ```
-curl -LO https://github.com/pact-foundation/pact-ruby-standalone/releases/download/<TAG_NAME>/pact-<PACKAGE_VERSION>-windows-x86_64.tar.gz
-unzip pact-<PACKAGE_VERSION>-windows-x86_64.tar.gz
+curl -LO https://github.com/pact-foundation/pact-ruby-standalone/releases/download/<TAG_NAME>/pact-<PACKAGE_VERSION>-windows-x86_64.zip
+unzip pact-<PACKAGE_VERSION>-windows-x86_64.zip
 ```
 
 #### x86
 
 ```
-curl -LO https://github.com/pact-foundation/pact-ruby-standalone/releases/download/<TAG_NAME>/pact-<PACKAGE_VERSION>-windows-x86.tar.gz
-unzip pact-<PACKAGE_VERSION>-windows-x86.tar.gz
+curl -LO https://github.com/pact-foundation/pact-ruby-standalone/releases/download/<TAG_NAME>/pact-<PACKAGE_VERSION>-windows-x86.zip
+unzip pact-<PACKAGE_VERSION>-windows-x86.zip
 ```
 


### PR DESCRIPTION
fixes #112 

Updates amended release note template to correct reference `.zip` file extension for Windows binaries