### PR TITLE
remove unused gemfile.lock files

### DIFF
--- a/tasks/package.rake
+++ b/tasks/package.rake
@@ -200,6 +200,9 @@ def remove_unnecessary_files package_dir
   sh "find #{package_dir}/lib/vendor/ruby -name '*.css' | xargs rm -f"
   sh "find #{package_dir}/lib/vendor/ruby -name '*.svg' | xargs rm -f"
 
+  # Remove unused Gemfile.lock files
+  sh "find #{package_dir}/lib/vendor/ruby -name 'Gemfile.lock' | xargs rm -f"
+
   # Uncommonly used encodings
   sh "rm -f #{package_dir}/lib/ruby/lib/ruby/*/*/enc/cp949*"
   sh "rm -f #{package_dir}/lib/ruby/lib/ruby/*/*/enc/euc_*"


### PR DESCRIPTION
Related issue: https://github.com/pact-foundation/pact-ruby-standalone/issues/83#issuecomment-1902816355

Based on the information from @bethesque the only used Gemfile.lock should be '/pact/Gemfile.lock'. Therefore all Gemfile.lock files in the `/lib/vendor/ruby` should be removed to not trigger false positives in a vulnerabilty reporting.