### PR TITLE
Revert "Revert "chore(deps): upgrade traveling-ruby to 20240205-3.3.0""

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 3.2.2
+        ruby-version: 3.3.0
     - name: Set up environment
       run: bundle install
     - name: Build

--- a/.github/workflows/manual_release.yml
+++ b/.github/workflows/manual_release.yml
@@ -35,7 +35,7 @@ jobs:
 
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 3.2.2
+        ruby-version: 3.3.0
 
     - name: Set up environment
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
 
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 3.2.2
+        ruby-version: 3.3.0
 
     - name: Set up environment
       run: |

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -15,7 +15,7 @@ jobs:
 
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 3.2.2
+        ruby-version: 3.3.0
 
     - name: Set up environment
       run: |

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -54,15 +54,15 @@ Script is designed to run on Linux, but can be run on macOS or windows.
 For windows x86_64
 
     cd windows
-    bash -c 'mkdir -p cache output/3.2.2'
-    bash -c './build-ruby -a x86 -r 3.2.2 cache output/3.2.2'
-    bash -c './package -r traveling-ruby-20230428-3.2.2-x86-windows.tar.gz output/3.2.2'
+    bash -c 'mkdir -p cache output/3.3.0'
+    bash -c './build-ruby -a x86 -r 3.3.0 cache output/3.3.0'
+    bash -c './package -r traveling-ruby-20230428-3.3.0-x86-windows.tar.gz output/3.3.0'
 
 For windows x86
 
-    bash -c 'mkdir -p cache output/3.2.2'
-    bash -c './build-ruby -a x86_64 -r 3.2.2 cache output/3.2.2'
-    bash -c './package -r traveling-ruby-20230428-3.2.2-x86_64-windows.tar.gz output/3.2.2'
+    bash -c 'mkdir -p cache output/3.3.0'
+    bash -c './build-ruby -a x86_64 -r 3.3.0 cache output/3.3.0'
+    bash -c './package -r traveling-ruby-20230428-3.3.0-x86_64-windows.tar.gz output/3.3.0'
 
 ### Building the pact-ruby-standalone packages
 
@@ -118,10 +118,10 @@ Build only selected platforms
 2. Copy your built `traveling-ruby` package into the `build` folder
 3. Ensure the version number in `tasks/package.rake` matches your package name
    1. eg
-      1. `traveling-ruby-20230508-3.2.2-linux-arm64.tar.gz`
+      1. `traveling-ruby-20230508-3.3.0-linux-arm64.tar.gz`
 
     ```ruby
-    TRAVELING_RUBY_VERSION = "20230508-3.2.2"
+    TRAVELING_RUBY_VERSION = "20230508-3.3.0"
     ```
 
 4. Run `bundle exec rake package` as before
@@ -130,13 +130,13 @@ Build only selected platforms
 
 | OS     | Ruby      | Architecture | Supported |
 | -------| ------- | ------------ | --------- |
-| OSX    | 3.2.2     | x86_64       | ✅         |
-| OSX    | 3.2.2     | aarch64 (arm)| ✅         |
-| Linux  | 3.2.2   | x86_64       | ✅         |
-| Linux  | 3.2.2   | aarch64 (arm)| ✅          |
-| Windows| 3.2.2 | x86_64       | ✅        |
-| Windows| 3.2.2 | x86       | ✅        |
-| Windows| 3.2.2 | aarch64 (via x86 emulation) |  ✅        |
+| OSX    | 3.3.0     | x86_64       | ✅         |
+| OSX    | 3.3.0     | aarch64 (arm)| ✅         |
+| Linux  | 3.3.0   | x86_64       | ✅         |
+| Linux  | 3.3.0   | aarch64 (arm)| ✅          |
+| Windows| 3.3.0 | x86_64       | ✅        |
+| Windows| 3.3.0 | x86       | ✅        |
+| Windows| 3.3.0 | aarch64 (via x86 emulation) |  ✅        |
 
 ## Testing
 

--- a/Dockerfile-bundle-base
+++ b/Dockerfile-bundle-base
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 ruby:3.2.2-alpine
+FROM --platform=linux/amd64 ruby:3.3.0-alpine
 
 # Installation path
 ENV HOME=/app
@@ -9,6 +9,6 @@ RUN set -ex && \
   chmod g+w $HOME && \
   apk add --update --no-cache make gcc libc-dev
 
-RUN gem install bundler -v "~> 2.4"
+RUN gem install bundler -v "~> 2.5"
 COPY packaging/Gemfile packaging/Gemfile.lock $HOME/
 RUN bundle install --no-cache

--- a/Dockerfile-package-base
+++ b/Dockerfile-package-base
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 ruby:3.2.2-slim
+FROM --platform=linux/amd64 ruby:3.3.0-slim
 
 RUN apt-get update && apt-get install -y \
     curl \
@@ -12,7 +12,7 @@ RUN useradd --create-home --home-dir $HOME user \
     && mkdir -p $HOME \
     && chown -R user:user $HOME
 
-RUN gem install bundler:2.4.0
+RUN gem install bundler:2.5.3
 RUN bundle install
 COPY Rakefile README.md Gemfile Gemfile.lock VERSION $HOME/
 COPY tasks $HOME/tasks

--- a/Dockerfile-release-base
+++ b/Dockerfile-release-base
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 ruby:3.2.2-alpine
+FROM --platform=linux/amd64 ruby:3.3.0-alpine
 
 # Installation path
 ENV HOME=/app
@@ -9,6 +9,6 @@ RUN set -ex && \
   chmod g+w $HOME && \
   apk add --update --no-cache make gcc libc-dev git
 
-RUN gem install bundler -v "~> 2.4"
+RUN gem install bundler -v "~> 2.5"
 COPY Gemfile Gemfile.lock $HOME/
 RUN bundle install --no-cache

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,23 +1,25 @@
 GEM
   remote: http://rubygems.org/
   specs:
-    addressable (2.8.3)
+    addressable (2.8.6)
       public_suffix (>= 2.0.2, < 6.0)
     bump (0.10.0)
     conventional-changelog (1.3.0)
-    faraday (2.7.4)
-      faraday-net_http (>= 2.0, < 3.1)
-      ruby2_keywords (>= 0.0.4)
-    faraday-net_http (3.0.2)
+    faraday (2.9.0)
+      faraday-net_http (>= 2.0, < 3.2)
+    faraday-net_http (3.1.0)
+      net-http
+    net-http (0.4.1)
+      uri
     octokit (4.25.1)
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
-    public_suffix (5.0.1)
+    public_suffix (5.0.4)
     rake (12.3.3)
-    ruby2_keywords (0.0.5)
     sawyer (0.9.2)
       addressable (>= 2.3.5)
       faraday (>= 0.17.3, < 3)
+    uri (0.13.0)
 
 PLATFORMS
   ruby
@@ -29,4 +31,4 @@ DEPENDENCIES
   rake (~> 12.3)
 
 BUNDLED WITH
-   2.4.10
+   2.5.3

--- a/README.md
+++ b/README.md
@@ -46,17 +46,17 @@ See the [release page][releases].
 
 ## Supported Platforms
 
-Ruby is not required on the host platform, Ruby 3.2.2 is provided in the distributable.
+Ruby is not required on the host platform, Ruby 3.3.0 is provided in the distributable.
 
 | OS     | Ruby      | Architecture   | Supported |
 | -------| -------   | ------------   | --------- |
-| MacOS  | 3.2.2     | x86_64         | ✅        |
-| MacOS  | 3.2.2     | aarch64 (arm64)| ✅        |
-| Linux  | 3.2.2     | x86_64         | ✅        |
-| Linux  | 3.2.2     | aarch64 (arm64)| ✅        |
-| Windows| 3.2.2     | x86_64         | ✅        |
-| Windows| 3.2.2     | x86            | ✅        |
-| Windows| 3.2.2     | aarch64 (arm64)| 🚧        |
+| MacOS  | 3.3.0     | x86_64         | ✅        |
+| MacOS  | 3.3.0     | aarch64 (arm64)| ✅        |
+| Linux  | 3.3.0     | x86_64         | ✅        |
+| Linux  | 3.3.0     | aarch64 (arm64)| ✅        |
+| Windows| 3.3.0     | x86_64         | ✅        |
+| Windows| 3.3.0     | x86            | ✅        |
+| Windows| 3.3.0     | aarch64 (arm64)| 🚧        |
 
 🚧 - Tested under emulation mode x86 / x86_64 in Windows on ARM
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,5 +2,5 @@
 
 Run:
 
-    chruby 3.2.2 #or whatever your version manager is
+    chruby 3.3.0 #or whatever your version manager is
     script/release.sh [major|minor|patch] # default is minor

--- a/packaging/Gemfile
+++ b/packaging/Gemfile
@@ -7,4 +7,4 @@ gem "pact-provider-verifier", "1.38.0"
 gem "pact_broker-client", "1.75.1"
 gem "webrick", "1.8.1"
 gem 'rack', '>= 2.2.6'
-gem "json", "2.6.3"
+gem "json", "2.7.1"

--- a/packaging/Gemfile.lock
+++ b/packaging/Gemfile.lock
@@ -2,25 +2,25 @@ GEM
   remote: http://rubygems.org/
   specs:
     awesome_print (1.9.2)
-    base64 (0.2.0)
-    diff-lcs (1.5.0)
+    diff-lcs (1.5.1)
     dig_rb (1.0.1)
     expgen (0.1.1)
       parslet
-    faraday (2.7.12)
-      base64
-      faraday-net_http (>= 2.0, < 3.1)
-      ruby2_keywords (>= 0.0.4)
-    faraday-net_http (3.0.2)
+    faraday (2.9.0)
+      faraday-net_http (>= 2.0, < 3.2)
+    faraday-net_http (3.1.0)
+      net-http
     faraday-retry (2.2.0)
       faraday (~> 2.0)
     find_a_port (1.0.1)
     httparty (0.21.0)
       mini_mime (>= 1.0.0)
       multi_xml (>= 0.5.2)
-    json (2.6.3)
+    json (2.7.1)
     mini_mime (1.1.5)
     multi_xml (0.6.0)
+    net-http (0.4.1)
+      uri
     pact (1.64.0)
       pact-mock_service (~> 3.0, >= 3.3.1)
       pact-support (~> 1.16, >= 1.16.9)
@@ -74,22 +74,21 @@ GEM
       rack (>= 1.3)
     rainbow (3.1.1)
     rake (13.1.0)
-    rspec (3.12.0)
-      rspec-core (~> 3.12.0)
-      rspec-expectations (~> 3.12.0)
-      rspec-mocks (~> 3.12.0)
-    rspec-core (3.12.2)
-      rspec-support (~> 3.12.0)
-    rspec-expectations (3.12.3)
+    rspec (3.13.0)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.0)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.12.0)
-    rspec-mocks (3.12.6)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.12.0)
-    rspec-support (3.12.1)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.0)
     rspec_junit_formatter (0.6.0)
       rspec-core (>= 2, < 4, != 2.12.0)
-    ruby2_keywords (0.0.5)
     sync (0.5.0)
     table_print (1.5.7)
     term-ansicolor (1.7.1)
@@ -97,18 +96,27 @@ GEM
     thor (1.3.0)
     tins (1.32.1)
       sync
+    uri (0.13.0)
     webrick (1.8.1)
 
 PLATFORMS
   aarch64-linux
+  arm64-darwin
   arm64-darwin-20
   arm64-darwin-21
   arm64-darwin-22
+  arm64-darwin-23
   ruby
   x64-mingw32
+  x86_64-darwin
+  x86_64-darwin-20
+  x86_64-darwin-21
+  x86_64-darwin-22
+  x86_64-darwin-23
+  x86_64-linux
 
 DEPENDENCIES
-  json (= 2.6.3)
+  json (= 2.7.1)
   pact (= 1.64.0)
   pact-message (= 0.11.1)
   pact-mock_service (= 3.11.2)
@@ -118,4 +126,4 @@ DEPENDENCIES
   webrick (= 1.8.1)
 
 BUNDLED WITH
-   2.4.0
+   2.5.3

--- a/packaging/README.md.template
+++ b/packaging/README.md.template
@@ -46,17 +46,17 @@ See the [release page][releases].
 
 ## Supported Platforms
 
-Ruby is not required on the host platform, Ruby 3.2.2 is provided in the distributable.
+Ruby is not required on the host platform, Ruby 3.3.0 is provided in the distributable.
 
 | OS     | Ruby      | Architecture   | Supported |
 | -------| -------   | ------------   | --------- |
-| MacOS  | 3.2.2     | x86_64         | ✅        |
-| MacOS  | 3.2.2     | aarch64 (arm64)| ✅        |
-| Linux  | 3.2.2     | x86_64         | ✅        |
-| Linux  | 3.2.2     | aarch64 (arm64)| ✅        |
-| Windows| 3.2.2     | x86_64         | ✅        |
-| Windows| 3.2.2     | x86            | ✅        |
-| Windows| 3.2.2     | aarch64 (arm64)| 🚧        |
+| MacOS  | 3.3.0     | x86_64         | ✅        |
+| MacOS  | 3.3.0     | aarch64 (arm64)| ✅        |
+| Linux  | 3.3.0     | x86_64         | ✅        |
+| Linux  | 3.3.0     | aarch64 (arm64)| ✅        |
+| Windows| 3.3.0     | x86_64         | ✅        |
+| Windows| 3.3.0     | x86            | ✅        |
+| Windows| 3.3.0     | aarch64 (arm64)| 🚧        |
 
 🚧 - Tested under emulation mode x86 / x86_64 in Windows on ARM
 

--- a/tasks/package.rake
+++ b/tasks/package.rake
@@ -3,7 +3,7 @@ require 'bundler/setup'
 
 PACKAGE_NAME = "pact"
 VERSION = File.read('VERSION').strip
-TRAVELING_RUBY_VERSION = "20230605-3.2.2"
+TRAVELING_RUBY_VERSION = "20240205-3.3.0"
 TRAVELING_RUBY_PKG_DATE = TRAVELING_RUBY_VERSION.split("-").first
 PLUGIN_CLI_VERSION = "0.1.0"
 
@@ -46,8 +46,8 @@ namespace :package do
   end
   desc "Install gems to local directory"
   task :bundle_install do
-    if RUBY_VERSION !~ /^3\.2\./
-      abort "You can only 'bundle install' using Ruby 3.2.2, because that's what Traveling Ruby uses."
+    if RUBY_VERSION !~ /^3\.3\./
+      abort "You can only 'bundle install' using Ruby 3.3.0, because that's what Traveling Ruby uses."
     end
     sh "rm -rf build/tmp"
     sh "mkdir -p build/tmp"


### PR DESCRIPTION
Reverts pact-foundation/pact-ruby-standalone#129

Updates to Ruby 3.3.0 + OpenSSL 3.2.0

Note:- pact-mock-service will now error when configured with an expired certificate

Check the cert date

```
openssl x509 -enddate -noout -in test/ssl/server.crt             
notAfter=Jan 21 10:45:15 2018 GMT
```

Start the mock service with the ssl params

```
standalone/darwin-arm64-2.3.0/pact/bin/pact-mock-service  --ssl --sslcert test/ssl/server.crt --sslkey test/ssl/server.key 
```

Output from mock server

```
INFO  WEBrick 1.8.1
INFO  ruby 3.2.2 (2023-03-30) [arm64-darwin22]
INFO  \nCertificate:\n    Data:\n        Version: 1 (0x0)\n        Serial Number:\n            f0:89:30:81:f3:af:b0:20\n        Signature Algorithm: sha1WithRSAEncryption\n        Issuer: C=AU, ST=Some-State, O=Internet Widgits Pty Ltd\n        Validity\n            Not Before: Jan 21 10:45:15 2017 GMT\n            Not After : Jan 21 10:45:15 2018 GMT\n        Subject: C=AU, ST=Some-State, O=Internet Widgits Pty Ltd\n        Subject Public Key Info:\n            Public Key Algorithm: rsaEncryption\n                RSA Public-Key: (1024 bit)\n                Modulus:\n                    00:aa:8d:ba:05:ef:d0:54:8a:dd:3e:84:70:26:80:\n                    b1:1d:62:57:73:68:5b:a9:61:77:90:76:d1:3b:78:\n                    5f:06:0c:be:67:3f:b2:cd:8e:db:d3:ca:60:09:45:\n                    ae:97:d9:f9:44:e9:43:22:56:7a:56:f1:4c:59:5a:\n                    b6:18:af:3b:54:1d:6a:cb:34:d8:f1:2a:5d:08:18:\n                    28:70:36:f2:f7:55:3e:a9:45:90:29:52:4f:00:b9:\n                    8b:b4:c8:d9:71:42:5a:15:99:2d:d2:02:92:ea:d7:\n                    83:98:08:2c:f9:9b:ac:10:63:49:61:9a:7b:83:d8:\n                    fb:61:18:10:be:2f:da:22:ef\n                Exponent: 65537 (0x10001)\n    Signature Algorithm: sha1WithRSAEncryption\n         08:34:0e:66:c3:60:d4:27:90:d8:67:90:ba:9f:32:e5:a7:43:\n         6b:76:3a:4b:17:6c:95:1d:5f:e4:e0:3b:ed:c0:bc:ce:f1:59:\n         d2:f7:21:0b:26:24:b3:13:47:0f:1c:44:39:e5:65:af:a4:47:\n         61:01:16:5f:7d:16:1f:a7:6c:c6:6c:28:10:4a:d5:03:7c:e9:\n         27:f0:75:fe:c5:a4:51:7d:b9:8e:94:de:2f:d4:7d:70:de:8b:\n         4c:5c:c7:1b:79:3c:78:3e:a5:66:c0:9f:34:aa:0c:bb:32:df:\n         d2:25:bf:ce:4d:1a:52:a8:ec:aa:63:2a:92:c6:cc:59:da:b7:\n         dd:12\n
INFO  WEBrick::HTTPServer#start: pid=26762 port=55701
```


Make a request with the cert

```
SSL_CERT_FILE=test/ssl/server.crt curl https://localhost:55701 
```

error for client

```
curl: (60) SSL certificate problem: certificate has expired
More details here: https://curl.se/docs/sslcerts.html

curl failed to verify the legitimacy of the server and therefore could not
establish a secure connection to it. To learn more about this situation and
how to fix it, please visit the web page mentioned above.
```

Error in mock server

```
INFO  WEBrick::HTTPServer#start: pid=26762 port=55701
ERROR OpenSSL::SSL::SSLError: SSL_accept returned=1 errno=0 peeraddr=(null) state=error: sslv3 alert certificate expired
        /Users/saf/dev/pact-foundation/pact-js-core/standalone/darwin-arm64-2.3.0/pact/lib/vendor/ruby/3.2.0/gems/webrick-1.8.1/lib/webrick/server.rb:302:in `accept'
        /Users/saf/dev/pact-foundation/pact-js-core/standalone/darwin-arm64-2.3.0/pact/lib/vendor/ruby/3.2.0/gems/webrick-1.8.1/lib/webrick/server.rb:302:in `block (2 levels) in start_thread'
        /Users/saf/dev/pact-foundation/pact-js-core/standalone/darwin-arm64-2.3.0/pact/lib/vendor/ruby/3.2.0/gems/webrick-1.8.1/lib/webrick/utils.rb:258:in `timeout'
        /Users/saf/dev/pact-foundation/pact-js-core/standalone/darwin-arm64-2.3.0/pact/lib/vendor/ruby/3.2.0/gems/webrick-1.8.1/lib/webrick/server.rb:300:in `block in start_thread'
```

Using a cert which is configured to expire in the future, results in a successful test run

- [commit](https://github.com/pact-foundation/pact-js-core/commit/d45093debffb745a46aad6c2db993f749fdd0eaa)
- [passing test run](https://github.com/pact-foundation/pact-js-core/actions/runs/7834333418)
- [prior failing test run](https://github.com/pact-foundation/pact-js-core/actions/runs/7831500184)