### PR TITLE
deps: upgrade to ruby 3.2.4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 3.2.3
+        ruby-version: 3.2.4
     - name: Set up environment
       run: bundle install
     - name: Build

--- a/.github/workflows/manual_release.yml
+++ b/.github/workflows/manual_release.yml
@@ -35,7 +35,7 @@ jobs:
 
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 3.2.3
+        ruby-version: 3.2.4
 
     - name: Set up environment
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
 
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 3.2.3
+        ruby-version: 3.2.4
 
     - name: Set up environment
       run: |

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -15,7 +15,7 @@ jobs:
 
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 3.2.3
+        ruby-version: 3.2.4
 
     - name: Set up environment
       run: |

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -54,15 +54,15 @@ Script is designed to run on Linux, but can be run on macOS or windows.
 For windows x86_64
 
     cd windows
-    bash -c 'mkdir -p cache output/3.2.3'
-    bash -c './build-ruby -a x86 -r 3.2.3 cache output/3.2.3'
-    bash -c './package -r traveling-ruby-20230428-3.2.3-x86-windows.tar.gz output/3.2.3'
+    bash -c 'mkdir -p cache output/3.2.4'
+    bash -c './build-ruby -a x86 -r 3.2.4 cache output/3.2.4'
+    bash -c './package -r traveling-ruby-20230428-3.2.4-x86-windows.tar.gz output/3.2.4'
 
 For windows x86
 
-    bash -c 'mkdir -p cache output/3.2.3'
-    bash -c './build-ruby -a x86_64 -r 3.2.3 cache output/3.2.3'
-    bash -c './package -r traveling-ruby-20230428-3.2.3-x86_64-windows.tar.gz output/3.2.3'
+    bash -c 'mkdir -p cache output/3.2.4'
+    bash -c './build-ruby -a x86_64 -r 3.2.4 cache output/3.2.4'
+    bash -c './package -r traveling-ruby-20230428-3.2.4-x86_64-windows.tar.gz output/3.2.4'
 
 ### Building the pact-ruby-standalone packages
 
@@ -118,10 +118,10 @@ Build only selected platforms
 2. Copy your built `traveling-ruby` package into the `build` folder
 3. Ensure the version number in `tasks/package.rake` matches your package name
    1. eg
-      1. `traveling-ruby-20230508-3.2.3-linux-arm64.tar.gz`
+      1. `traveling-ruby-20230508-3.2.4-linux-arm64.tar.gz`
 
     ```ruby
-    TRAVELING_RUBY_VERSION = "20230508-3.2.3"
+    TRAVELING_RUBY_VERSION = "20230508-3.2.4"
     ```
 
 4. Run `bundle exec rake package` as before
@@ -130,13 +130,13 @@ Build only selected platforms
 
 | OS     | Ruby      | Architecture | Supported |
 | -------| ------- | ------------ | --------- |
-| OSX    | 3.2.3     | x86_64       | ✅         |
-| OSX    | 3.2.3     | aarch64 (arm)| ✅         |
-| Linux  | 3.2.3   | x86_64       | ✅         |
-| Linux  | 3.2.3   | aarch64 (arm)| ✅          |
-| Windows| 3.2.3 | x86_64       | ✅        |
-| Windows| 3.2.3 | x86       | ✅        |
-| Windows| 3.2.3 | aarch64 (via x86 emulation) |  ✅        |
+| OSX    | 3.2.4     | x86_64       | ✅         |
+| OSX    | 3.2.4     | aarch64 (arm)| ✅         |
+| Linux  | 3.2.4   | x86_64       | ✅         |
+| Linux  | 3.2.4   | aarch64 (arm)| ✅          |
+| Windows| 3.2.4 | x86_64       | ✅        |
+| Windows| 3.2.4 | x86       | ✅        |
+| Windows| 3.2.4 | aarch64 (via x86 emulation) |  ✅        |
 
 ## Testing
 

--- a/Dockerfile-bundle-base
+++ b/Dockerfile-bundle-base
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 ruby:3.2.3-alpine
+FROM --platform=linux/amd64 ruby:3.2.4-alpine
 
 # Installation path
 ENV HOME=/app

--- a/Dockerfile-package-base
+++ b/Dockerfile-package-base
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 ruby:3.2.3-slim
+FROM --platform=linux/amd64 ruby:3.2.4-slim
 
 RUN apt-get update && apt-get install -y \
     curl \
@@ -12,7 +12,7 @@ RUN useradd --create-home --home-dir $HOME user \
     && mkdir -p $HOME \
     && chown -R user:user $HOME
 
-RUN gem install bundler:2.5.3
+RUN gem install bundler:2.5.9
 RUN bundle install
 COPY Rakefile README.md Gemfile Gemfile.lock VERSION $HOME/
 COPY tasks $HOME/tasks

--- a/Dockerfile-release-base
+++ b/Dockerfile-release-base
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 ruby:3.2.3-alpine
+FROM --platform=linux/amd64 ruby:3.2.4-alpine
 
 # Installation path
 ENV HOME=/app

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,4 +31,4 @@ DEPENDENCIES
   rake (~> 12.3)
 
 BUNDLED WITH
-   2.5.3
+   2.5.9

--- a/README.md
+++ b/README.md
@@ -46,17 +46,17 @@ See the [release page][releases].
 
 ## Supported Platforms
 
-Ruby is not required on the host platform, Ruby 3.2.3 is provided in the distributable.
+Ruby is not required on the host platform, Ruby 3.2.4 is provided in the distributable.
 
 | OS     | Ruby      | Architecture   | Supported |
 | -------| -------   | ------------   | --------- |
-| MacOS  | 3.2.3     | x86_64         | ✅        |
-| MacOS  | 3.2.3     | aarch64 (arm64)| ✅        |
-| Linux  | 3.2.3     | x86_64         | ✅        |
-| Linux  | 3.2.3     | aarch64 (arm64)| ✅        |
-| Windows| 3.2.3     | x86_64         | ✅        |
-| Windows| 3.2.3     | x86            | ✅        |
-| Windows| 3.2.3     | aarch64 (arm64)| 🚧        |
+| MacOS  | 3.2.4     | x86_64         | ✅        |
+| MacOS  | 3.2.4     | aarch64 (arm64)| ✅        |
+| Linux  | 3.2.4     | x86_64         | ✅        |
+| Linux  | 3.2.4     | aarch64 (arm64)| ✅        |
+| Windows| 3.2.4     | x86_64         | ✅        |
+| Windows| 3.2.4     | x86            | ✅        |
+| Windows| 3.2.4     | aarch64 (arm64)| 🚧        |
 
 🚧 - Tested under emulation mode x86 / x86_64 in Windows on ARM
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,5 +2,5 @@
 
 Run:
 
-    chruby 3.2.3 #or whatever your version manager is
+    chruby 3.2.4 #or whatever your version manager is
     script/release.sh [major|minor|patch] # default is minor

--- a/packaging/Gemfile
+++ b/packaging/Gemfile
@@ -7,4 +7,8 @@ gem "pact-provider-verifier", "1.38.0"
 gem "pact_broker-client", "1.75.1"
 gem "webrick", "1.8.1"
 gem 'rack', '>= 2.2.6'
+# see https://stdgems.org/ for versions to lock to
+# we require gem locking for gems with native extensions
+# due to lack of windows support
 gem "json", "2.6.3"
+gem "bigdecimal", "3.1.3"

--- a/packaging/Gemfile.lock
+++ b/packaging/Gemfile.lock
@@ -2,6 +2,8 @@ GEM
   remote: http://rubygems.org/
   specs:
     awesome_print (1.9.2)
+    bigdecimal (3.1.3)
+    csv (3.3.0)
     diff-lcs (1.5.1)
     dig_rb (1.0.1)
     expgen (0.1.1)
@@ -10,15 +12,17 @@ GEM
       faraday-net_http (>= 2.0, < 3.2)
     faraday-net_http (3.1.0)
       net-http
-    faraday-retry (2.2.0)
+    faraday-retry (2.2.1)
       faraday (~> 2.0)
     find_a_port (1.0.1)
-    httparty (0.21.0)
+    httparty (0.22.0)
+      csv
       mini_mime (>= 1.0.0)
       multi_xml (>= 0.5.2)
     json (2.6.3)
     mini_mime (1.1.5)
-    multi_xml (0.6.0)
+    multi_xml (0.7.1)
+      bigdecimal (~> 3.1)
     net-http (0.4.1)
       uri
     pact (1.64.0)
@@ -64,7 +68,7 @@ GEM
       term-ansicolor (~> 1.7)
       thor (>= 0.20, < 2.0)
     parslet (2.0.0)
-    rack (2.2.8.1)
+    rack (2.2.9)
     rack-proxy (0.7.7)
       rack
     rack-reverse-proxy (0.12.0)
@@ -73,7 +77,7 @@ GEM
     rack-test (2.1.0)
       rack (>= 1.3)
     rainbow (3.1.1)
-    rake (13.1.0)
+    rake (13.2.1)
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
@@ -83,7 +87,7 @@ GEM
     rspec-expectations (3.13.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
-    rspec-mocks (3.13.0)
+    rspec-mocks (3.13.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-support (3.13.1)
@@ -91,10 +95,11 @@ GEM
       rspec-core (>= 2, < 4, != 2.12.0)
     sync (0.5.0)
     table_print (1.5.7)
-    term-ansicolor (1.7.1)
+    term-ansicolor (1.8.0)
       tins (~> 1.0)
     thor (1.3.1)
-    tins (1.32.1)
+    tins (1.33.0)
+      bigdecimal
       sync
     uri (0.13.0)
     webrick (1.8.1)
@@ -116,6 +121,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  bigdecimal (= 3.1.3)
   json (= 2.6.3)
   pact (= 1.64.0)
   pact-message (= 0.11.1)
@@ -126,4 +132,4 @@ DEPENDENCIES
   webrick (= 1.8.1)
 
 BUNDLED WITH
-   2.5.3
+   2.5.9

--- a/packaging/README.md.template
+++ b/packaging/README.md.template
@@ -46,17 +46,17 @@ See the [release page][releases].
 
 ## Supported Platforms
 
-Ruby is not required on the host platform, Ruby 3.2.3 is provided in the distributable.
+Ruby is not required on the host platform, Ruby 3.2.4 is provided in the distributable.
 
 | OS     | Ruby      | Architecture   | Supported |
 | -------| -------   | ------------   | --------- |
-| MacOS  | 3.2.3     | x86_64         | ✅        |
-| MacOS  | 3.2.3     | aarch64 (arm64)| ✅        |
-| Linux  | 3.2.3     | x86_64         | ✅        |
-| Linux  | 3.2.3     | aarch64 (arm64)| ✅        |
-| Windows| 3.2.3     | x86_64         | ✅        |
-| Windows| 3.2.3     | x86            | ✅        |
-| Windows| 3.2.3     | aarch64 (arm64)| 🚧        |
+| MacOS  | 3.2.4     | x86_64         | ✅        |
+| MacOS  | 3.2.4     | aarch64 (arm64)| ✅        |
+| Linux  | 3.2.4     | x86_64         | ✅        |
+| Linux  | 3.2.4     | aarch64 (arm64)| ✅        |
+| Windows| 3.2.4     | x86_64         | ✅        |
+| Windows| 3.2.4     | x86            | ✅        |
+| Windows| 3.2.4     | aarch64 (arm64)| 🚧        |
 
 🚧 - Tested under emulation mode x86 / x86_64 in Windows on ARM
 

--- a/tasks/package.rake
+++ b/tasks/package.rake
@@ -3,9 +3,9 @@ require 'bundler/setup'
 
 PACKAGE_NAME = "pact"
 VERSION = File.read('VERSION').strip
-TRAVELING_RUBY_VERSION = "20240205-3.2.3"
+TRAVELING_RUBY_VERSION = "20240427-3.2.4"
 TRAVELING_RUBY_PKG_DATE = TRAVELING_RUBY_VERSION.split("-").first
-PLUGIN_CLI_VERSION = "0.1.0"
+PLUGIN_CLI_VERSION = "0.1.2"
 
 desc "Package pact-ruby-standalone for OSX, Linux x86_64 and windows x86_64"
 task :package => ['package:linux:x86_64','package:linux:arm64', 'package:osx:x86_64', 'package:osx:arm64','package:windows:x86_64','package:windows:x86']
@@ -47,7 +47,7 @@ namespace :package do
   desc "Install gems to local directory"
   task :bundle_install do
     if RUBY_VERSION !~ /^3\.2\./
-      abort "You can only 'bundle install' using Ruby 3.2.3, because that's what Traveling Ruby uses."
+      abort "You can only 'bundle install' using Ruby 3.2.4, because that's what Traveling Ruby uses."
     end
     sh "rm -rf build/tmp"
     sh "mkdir -p build/tmp"


### PR DESCRIPTION
- [fix: pin bigdecimal to 3.1.5 as per ruby std gems](https://github.com/pact-foundation/pact-ruby-standalone/commit/dc0d352dd4fc35961f0e3bf85832bdf1c3522295)
- [chore(deps): update gems](https://github.com/pact-foundation/pact-ruby-standalone/commit/2ad27489debbd078a7a35b8eadf6eee6f8606919) 

    bigdecimal (3.1.3)
    csv (3.3.0)
    faraday-retry (2.2.1)
    multi_xml (0.7.1)
    rack (2.2.9)
    rake (13.2.1)
    rspec-mocks (3.13.1)
    term-ansicolor (1.8.0)
    tins (1.33.0)
- [deps: upgrade to ruby 3.2.4](https://github.com/pact-foundation/pact-ruby-standalone/commit/f0b431589d42a7d77c62bd97bb172d0002155826)
- Updates pact-plugin-cli to 0.1.2 which includes static built binaries (linked against musl), fixes #102 