### PR TITLE
Feat/rust tools

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,9 +48,3 @@ jobs:
       uses: actions/download-artifact@v4
     - name: test ${{ matrix.os }} package
       run: ./script/unpack-and-test.sh
-    - name: test x86 package
-      if: ${{ runner.os == 'Windows'}}
-      run: ./script/unpack-and-test.sh
-      env:
-        BINARY_OS: 'windows'
-        BINARY_ARCH: 'x86'

--- a/README.md
+++ b/README.md
@@ -2,7 +2,10 @@
 
 ![Build](https://github.com/pact-foundation/pact-ruby-standalone/workflows/Build/badge.svg)
 
-Creates a standalone pact command line executable using the ruby pact implementation and Traveling Ruby
+Creates a standalone pact command line executable containing
+
+- The rust pact implementation via cargo executables
+- The ruby pact implementation via Traveling Ruby
 
 ## Package contents
 
@@ -14,28 +17,44 @@ This version (2.4.26) of the Pact standalone executables package contains:
   * pact-provider-verifier gem 1.39.1
   * pact_broker-client gem 1.77.0
   * pact-message gem 0.11.1
+  * [pact_mock_server_cli](https://github.com/pact-foundation/pact-core-mock-server/tree/main/pact_mock_server_cli)
+  * [pact-stub-server](https://github.com/pact-foundation/pact-stub-server)
+  * [pact_verifier_cli](https://github.com/pact-foundation/pact-reference/tree/master/rust/pact_verifier_cli)
+  * [pact-plugin-cli](https://github.com/pact-foundation/pact-plugins/tree/main/cli)
 
 Binaries will be extracted into `pact/bin`:
 
 ```
 ./pact/bin/
-├── pact
+├── pact (central entry point to all binaries)
 ├── pact-broker
 ├── pactflow
-├── pact-message
-├── pact-mock-service
-├── pact-provider-verifier
-└── pact-stub-service
+├── pact_mock_server_cli
+├── pact-stub-server
+├── pact_verifier_cli
+├── pact-plugin-cli
+├── pact-message (legacy)
+├── pact-mock-service (legacy)
+├── pact-provider-verifier (legacy)
+└── pact-stub-service (legacy)
 ```
 
 ### Windows Users
 
-Please append `.bat` to any of the provided binaries
+Please append `.bat` to any of the provided ruby-based binaries
 
 eg.
 
 ```ps1
   .\pact\bin\pact-broker.bat
+```
+
+Please append `.exe` to any of the provided rust based binaries
+
+eg.
+
+```ps1
+  .\pact\bin\pact_mock_server_cli.exe
 ```
 
 ## Installation
@@ -55,10 +74,9 @@ Ruby is not required on the host platform, Ruby 3.3.5 is provided in the distrib
 | Linux  | 3.3.5     | x86_64         | ✅        |
 | Linux  | 3.3.5     | aarch64 (arm64)| ✅        |
 | Windows| 3.3.5     | x86_64         | ✅        |
-| Windows| 3.3.5     | x86            | ✅        |
 | Windows| 3.3.5     | aarch64 (arm64)| 🚧        |
 
-🚧 - Tested under emulation mode x86 / x86_64 in Windows on ARM
+🚧 - Tested under emulation mode x86_64 in Windows on ARM
 
 ## Usage
 
@@ -67,14 +85,14 @@ Ruby is not required on the host platform, Ruby 3.3.5 is provided in the distrib
 
 ```
 Commands:
-  pact-mock-service control               # Run a Pact mock service control s...
-  pact-mock-service control-restart       # Start a Pact mock service control...
-  pact-mock-service control-start         # Start a Pact mock service control...
-  pact-mock-service control-stop          # Stop a Pact mock service control ...
-  pact-mock-service help [COMMAND]        # Describe available commands or on...
-  pact-mock-service restart               # Start or restart a mock service. ...
-  pact-mock-service service               # Start a mock service. If the cons...
-  pact-mock-service start                 # Start a mock service. If the cons...
+  pact-mock-service control               # Run a Pact mock service control server.
+  pact-mock-service control-restart       # Start a Pact mock service control server.
+  pact-mock-service control-start         # Start a Pact mock service control server.
+  pact-mock-service control-stop          # Stop a Pact mock service control server.
+  pact-mock-service help [COMMAND]        # Describe available commands or one specific command
+  pact-mock-service restart               # Start or restart a mock service. If the consumer, provider and pact-dir options are provided, the pact will be writt...
+  pact-mock-service service               # Start a mock service. If the consumer, provider and pact-dir options are provided, the pact will be written automati...
+  pact-mock-service start                 # Start a mock service. If the consumer, provider and pact-dir options are provided, the pact will be written automati...
   pact-mock-service stop -p, --port=PORT  # Stop a Pact mock service
   pact-mock-service version               # Show the pact-mock-service gem version
 
@@ -129,16 +147,11 @@ Options:
       [--sslkey=SSLKEY]                    # Specify the path to the SSL key to use when running the service over HTTPS
 
 Description:
-  Start a stub service with the given pact file(s) or directories. Pact URIs
-  may be local file or directory paths, or HTTP. Include any basic auth details
-  in the URL using the format https://USERNAME:PASSWORD@URI. Where multiple
-  matching interactions are found, the interactions will be sorted by response
-  status, and the first one will be returned. This may lead to some
-  non-deterministic behaviour. If you are having problems with this, please
-  raise it on the pact-dev google group, and we can discuss some potential
-  enhancements. Note that only versions 1 and 2 of the pact specification are
-  currently fully supported. Pacts using the v3 format may be used, however,
-  any matching features added in v3 will currently be ignored.
+  Start a stub service with the given pact file(s) or directories. Pact URIs may be local file or directory paths, or HTTP. Include any basic auth details in the
+  URL using the format https://USERNAME:PASSWORD@URI. Where multiple matching interactions are found, the interactions will be sorted by response status, and the
+  first one will be returned. This may lead to some non-deterministic behaviour. If you are having problems with this, please raise it on the pact-dev google
+  group, and we can discuss some potential enhancements. Note that only versions 1 and 2 of the pact specification are currently fully supported. Pacts using the
+  v3 format may be used, however, any matching features added in v3 will currently be ignored.
 
 ```
 
@@ -192,24 +205,19 @@ Description:
   --enable-pending
   --include-wip-pacts-since
   
-  To
-  verify a pact at a known URL (eg. when a verification is triggered by a
-  'contract content changed' webhook), pass in the pact URL(s) as the first
-  argument(s) to the command, and do NOT set any of the other parameters apart
-  from the base URL and credentials.
+  To verify a pact at a known URL (eg. when a verification is triggered by a 'contract
+  content changed' webhook), pass in the pact URL(s) as the first argument(s) to the command, and do NOT set any of the other parameters apart from the base URL
+  and credentials.
   
-  To publish verification results for either of the above
-  scenarios, set:
+  To publish verification results for either of the above scenarios, set:
   
   --publish-verification-results (REQUIRED)
   --provider-app-version (REQUIRED)
   --provider-version-tag or --tag-with-git-branch
   
   
-  Selectors: These are specified using JSON strings.
-  The keys are 'tag' (the name of the consumer version tag), 'latest'
-  (true|false), 'consumer', and 'fallbackTag'. For example '{\"tag\":
-  \"master\", \"latest\": true}'. For a detailed explanation of selectors, see https://pact.io/selectors#consumer-version-selectors
+  Selectors: These are specified using JSON strings. The keys are 'tag' (the name of the consumer version tag), 'latest' (true|false),
+  'consumer', and 'fallbackTag'. For example '{\"tag\": \"master\", \"latest\": true}'. For a detailed explanation of selectors, see https://pact.io/selectors#consumer-version-selectors
 
 ```
 
@@ -282,66 +290,44 @@ Options:
                                                                  # Default: false
 
 Description:
-  Returns exit code 0 or 1, indicating whether or not the specified application
-  (pacticipant) has a successful verification result with each of the
-  application versions that are already deployed to a particular environment.
-  Prints out the relevant pact/verification details, indicating any missing or
-  failed verification results.
+  Returns exit code 0 or 1, indicating whether or not the specified application (pacticipant) has a successful verification result with each of the application
+  versions that are already deployed to a particular environment. Prints out the relevant pact/verification details, indicating any missing or failed verification
+  results.
 
-  The can-i-deploy tool was originally written to support specifying versions
-  and dependencies using tags. This usage has now been superseded by first
-  class support for environments, deployments and releases. For documentation
-  on how to use can-i-deploy with tags, please see
+  The can-i-deploy tool was originally written to support specifying versions and dependencies using tags. This usage has now been superseded by first class
+  support for environments, deployments and releases. For documentation on how to use can-i-deploy with tags, please see
   https://docs.pact.io/pact_broker/client_cli/can_i_deploy_usage_with_tags/
 
-  Before `can-i-deploy` can be used, the relevant environment resources must
-  first be created in the Pact Broker using the `create-environment` command.
-  The "test" and "production" environments will have been seeded for you. You
-  can check the existing environments by running `pact-broker
-  list-environments`. See
-  https://docs.pact.io/pact_broker/client_cli/readme#environments for more
-  information.
+  Before `can-i-deploy` can be used, the relevant environment resources must first be created in the Pact Broker using the `create-environment` command. The
+  "test" and "production" environments will have been seeded for you. You can check the existing environments by running `pact-broker list-environments`. See
+  https://docs.pact.io/pact_broker/client_cli/readme#environments for more information.
 
-  $ pact-broker create-environment --name "uat" --display-name "UAT"
-  --no-production
+  $ pact-broker create-environment --name "uat" --display-name "UAT" --no-production
 
-  After an application is deployed or released, its deployment must be recorded
-  using the `record-deployment` or `record-release` commands. See
-  https://docs.pact.io/pact_broker/recording_deployments_and_releases/ for more
-  information.
+  After an application is deployed or released, its deployment must be recorded using the `record-deployment` or `record-release` commands. See
+  https://docs.pact.io/pact_broker/recording_deployments_and_releases/ for more information.
 
-  $ pact-broker record-deployment --pacticipant Foo --version 173153ae0
-  --environment uat
+  $ pact-broker record-deployment --pacticipant Foo --version 173153ae0 --environment uat
 
-  Before an application is deployed or released to an environment, the
-  can-i-deploy command must be run to check that the application version is
-  safe to deploy with the versions of each integrated application that are
-  already in that environment.
+  Before an application is deployed or released to an environment, the can-i-deploy command must be run to check that the application version is safe to deploy
+  with the versions of each integrated application that are already in that environment.
 
-  $ pact-broker can-i-deploy --pacticipant PACTICIPANT --version VERSION
-  --to-environment ENVIRONMENT
+  $ pact-broker can-i-deploy --pacticipant PACTICIPANT --version VERSION --to-environment ENVIRONMENT
 
-  Example: can I deploy version 173153ae0 of application Foo to the test
-  environment?
+  Example: can I deploy version 173153ae0 of application Foo to the test environment?
 
-  $ pact-broker can-i-deploy --pacticipant Foo --version 173153ae0
-  --to-environment test
+  $ pact-broker can-i-deploy --pacticipant Foo --version 173153ae0 --to-environment test
 
-  Can-i-deploy can also be used to check if arbitrary versions have a
-  successful verification. When asking "Can I deploy this application version
-  with the latest version from the main branch of another application" it
-  functions as a "can I merge" check.
+  Can-i-deploy can also be used to check if arbitrary versions have a successful verification. When asking "Can I deploy this application version with the latest
+  version from the main branch of another application" it functions as a "can I merge" check.
 
-  $ pact-broker can-i-deploy --pacticipant Foo 173153ae0 \ --pacticipant Bar
-  --latest main
+  $ pact-broker can-i-deploy --pacticipant Foo 173153ae0 \ --pacticipant Bar --latest main
 
   ##### Polling
 
-  If the verification process takes a long time and there are results missing
-  when the can-i-deploy command runs in your CI/CD pipeline, you can configure
-  the command to poll and wait for the missing results to arrive. The arguments
-  to specify are `--retry-while-unknown TIMES` and `--retry-interval SECONDS`,
-  set to appropriate values for your pipeline.
+  If the verification process takes a long time and there are results missing when the can-i-deploy command runs in your CI/CD pipeline, you can configure the
+  command to poll and wait for the missing results to arrive. The arguments to specify are `--retry-while-unknown TIMES` and `--retry-interval SECONDS`, set to
+  appropriate values for your pipeline.
 
 ```
 
@@ -395,9 +381,9 @@ Usage:
 
 Options:
   [--pact-dir=PACT_DIR]  # Directory containing the pacts
-                         # Default: /home/runner/work/pact-ruby-standalone/pact-ruby-standalone/build/tmp/spec/pacts
+                         # Default: /Users/yousaf.nabi/dev/pact-foundation/pact-ruby-standalone/build/tmp/spec/pacts
   [--doc-dir=DOC_DIR]    # Documentation directory
-                         # Default: /home/runner/work/pact-ruby-standalone/pact-ruby-standalone/build/tmp/doc/pacts
+                         # Default: /Users/yousaf.nabi/dev/pact-foundation/pact-ruby-standalone/build/tmp/doc/pacts
 
 Generate Pact documentation in markdown
 
@@ -407,10 +393,10 @@ Generate Pact documentation in markdown
 
 ```
 Commands:
-  pact-message help [COMMAND]                                                ...
-  pact-message reify                                                         ...
-  pact-message update MESSAGE_JSON --consumer=CONSUMER --pact-dir=PACT_DIR --...
-  pact-message version                                                       ...
+  pact-message help [COMMAND]                                                                   # Describe available commands or one specific command
+  pact-message reify                                                                            # Take a JSON document with embedded pact matchers and return a ...
+  pact-message update MESSAGE_JSON --consumer=CONSUMER --pact-dir=PACT_DIR --provider=PROVIDER  # Update/create a pact. If MESSAGE_JSON is omitted or '-', it is...
+  pact-message version                                                                          # Show the pact-message gem version
 
 
 ```

--- a/packaging/README.md.template
+++ b/packaging/README.md.template
@@ -26,17 +26,17 @@ Binaries will be extracted into `pact/bin`:
 
 ```
 ./pact/bin/
-├── pact
+├── pact (central entry point to all binaries)
 ├── pact-broker
 ├── pactflow
-├── pact-message
-├── pact-mock-service
-├── pact-provider-verifier
-├── pact-stub-service
-├── pact_mock_server_cli (rust)
-├── pact-stub-server (rust)
-├── pact_verifier_cli (rust)
-└── pact-plugin-cli (rust)
+├── pact_mock_server_cli
+├── pact-stub-server
+├── pact_verifier_cli
+├── pact-plugin-cli
+├── pact-message (legacy)
+├── pact-mock-service (legacy)
+├── pact-provider-verifier (legacy)
+└── pact-stub-service (legacy)
 ```
 
 ### Windows Users

--- a/packaging/README.md.template
+++ b/packaging/README.md.template
@@ -2,7 +2,10 @@
 
 ![Build](https://github.com/pact-foundation/pact-ruby-standalone/workflows/Build/badge.svg)
 
-Creates a standalone pact command line executable using the ruby pact implementation and Traveling Ruby
+Creates a standalone pact command line executable containing
+
+- The rust pact implementation via cargo executables
+- The ruby pact implementation via Traveling Ruby
 
 ## Package contents
 
@@ -14,6 +17,10 @@ This version (<%= ENV.fetch('VERSION') %>) of the Pact standalone executables pa
   * pact-provider-verifier gem <%= Pact::ProviderVerifier::VERSION %>
   * pact_broker-client gem <%= PactBroker::Client::VERSION %>
   * pact-message gem <%= Pact::Message::VERSION %>
+  * [pact_mock_server_cli](https://github.com/pact-foundation/pact-core-mock-server/tree/main/pact_mock_server_cli)
+  * [pact-stub-server](https://github.com/pact-foundation/pact-stub-server)
+  * [pact_verifier_cli](https://github.com/pact-foundation/pact-reference/tree/master/rust/pact_verifier_cli)
+  * [pact-plugin-cli](https://github.com/pact-foundation/pact-plugins/tree/main/cli)
 
 Binaries will be extracted into `pact/bin`:
 
@@ -25,17 +32,29 @@ Binaries will be extracted into `pact/bin`:
 ├── pact-message
 ├── pact-mock-service
 ├── pact-provider-verifier
-└── pact-stub-service
+├── pact-stub-service
+├── pact_mock_server_cli (rust)
+├── pact-stub-server (rust)
+├── pact_verifier_cli (rust)
+└── pact-plugin-cli (rust)
 ```
 
 ### Windows Users
 
-Please append `.bat` to any of the provided binaries
+Please append `.bat` to any of the provided ruby-based binaries
 
 eg.
 
 ```ps1
   .\pact\bin\pact-broker.bat
+```
+
+Please append `.exe` to any of the provided rust based binaries
+
+eg.
+
+```ps1
+  .\pact\bin\pact_mock_server_cli.exe
 ```
 
 ## Installation
@@ -55,10 +74,9 @@ Ruby is not required on the host platform, Ruby 3.3.5 is provided in the distrib
 | Linux  | 3.3.5     | x86_64         | ✅        |
 | Linux  | 3.3.5     | aarch64 (arm64)| ✅        |
 | Windows| 3.3.5     | x86_64         | ✅        |
-| Windows| 3.3.5     | x86            | ✅        |
 | Windows| 3.3.5     | aarch64 (arm64)| 🚧        |
 
-🚧 - Tested under emulation mode x86 / x86_64 in Windows on ARM
+🚧 - Tested under emulation mode x86_64 in Windows on ARM
 
 ## Usage
 

--- a/packaging/RELEASE_NOTES.md.template
+++ b/packaging/RELEASE_NOTES.md.template
@@ -50,11 +50,3 @@ tar xzf pact-<PACKAGE_VERSION>-linux-arm64.tar.gz
 curl -LO https://github.com/pact-foundation/pact-ruby-standalone/releases/download/<TAG_NAME>/pact-<PACKAGE_VERSION>-windows-x86_64.zip
 unzip pact-<PACKAGE_VERSION>-windows-x86_64.zip
 ```
-
-#### x86
-
-```
-curl -LO https://github.com/pact-foundation/pact-ruby-standalone/releases/download/<TAG_NAME>/pact-<PACKAGE_VERSION>-windows-x86.zip
-unzip pact-<PACKAGE_VERSION>-windows-x86.zip
-```
-

--- a/packaging/pact.rb
+++ b/packaging/pact.rb
@@ -1,15 +1,92 @@
-require 'pact/cli'
+#!/usr/bin/env ruby
+# frozen_string_literal: true
 
-class Thor
-  module Base
-    module ClassMethods
+INTERNAL_APP = ARGV[0].to_s
+FILENAME = File.basename($PROGRAM_NAME).split.first.chomp(".rb")
 
-      def basename
-        # chomps the trailing .rb so it doesn't show in the help text
-        File.basename($PROGRAM_NAME).split(" ").first.chomp(".rb")
-      end
-    end
+case ARGV[0]
+when "pact"
+  ARGV.shift
+  require "pact/cli"
+  Pact::CLI.start
+when "pactflow"
+  ARGV.shift
+  require "pactflow/client/cli/pactflow"
+  Pactflow::Client::CLI::Pactflow.start
+when "stub-service"
+  ARGV.shift
+  require "pact/stub_service/cli"
+  Pact::StubService::CLI.start
+when "provider-verifier"
+  ARGV.shift
+  ENV["PACT_EXECUTING_LANGUAGE"] ||= "unknown"
+  require "pact/provider_verifier/cli/verify"
+  Pact::ProviderVerifier::CLI::Verify.start
+when "mock-service"
+  ARGV.shift
+  require "pact/mock_service/cli"
+  Pact::MockService::CLI.start
+when "message"
+  ARGV.shift
+  require "pact/message/cli"
+  Pact::Message::CLI.start
+when "broker", "pact-broker"
+  ARGV.shift
+  require "pact_broker/client/cli/broker"
+  if ENV["PACT_BROKER_DISABLE_SSL_VERIFICATION"] == "true" || ENV["PACT_DISABLE_SSL_VERIFICATION"] == "true"
+    require "openssl"
+    OpenSSL::SSL::VERIFY_PEER = OpenSSL::SSL::VERIFY_NONE
+    warn "
+    WARN: SSL verification has been disabled by a dodgy hack
+    (reassigning the VERIFY_PEER constant to VERIFY_NONE).
+    You acknowledge that you do this at your own risk!
+    "
   end
+  PactBroker::Client::CLI::Broker.start
+when 'plugin'
+      ARGV.shift
+      output = `#{File.expand_path("../../bin/pact-plugin-cli", __dir__)} #{ARGV.join(" ")}`
+      exit_status = $?.exitstatus
+      puts output
+      exit(exit_status)
+when 'verifier'
+      ARGV.shift
+      output = `#{File.expand_path("../../bin/pact_verifier_cli", __dir__)} #{ARGV.join(" ")}`
+      exit_status = $?.exitstatus
+      puts output
+      exit(exit_status)
+when 'mock-server'
+      ARGV.shift
+      IO.popen([File.expand_path("../../bin/pact_mock_server_cli", __dir__), *ARGV], err: [:child, :out]) do |io|
+        while (line = io.gets)
+          $stdout.write(line)
+        end
+        exit_status = Process.wait2(io.pid)[1].exitstatus
+        exit(exit_status)
+      end
+when 'stub-server'
+  ARGV.shift
+  IO.popen([File.expand_path("../../bin/pact-stub-server", __dir__), *ARGV], err: [:child, :out]) do |io|
+    while (line = io.gets)
+      $stdout.write(line)
+    end
+    exit_status = Process.wait2(io.pid)[1].exitstatus
+    exit(exit_status)
+  end
+else
+  puts "available commands:"
+  puts "__________________"
+  puts "#{FILENAME} help"
+  puts "#{FILENAME} pact"
+  puts "#{FILENAME} pactflow"
+  puts "#{FILENAME} stub-server"
+  puts "#{FILENAME} verifier"
+  puts "#{FILENAME} mock-server"
+  puts "#{FILENAME} message"
+  puts "#{FILENAME} broker"
+  puts "#{FILENAME} pact-broker"
+  puts "#{FILENAME} plugin"
+  puts "#{FILENAME} stub-service (legacy)"
+  puts "#{FILENAME} provider-verifier (legacy)"
+  puts "#{FILENAME} mock-service (legacy)"
 end
-
-Pact::CLI.start

--- a/script/test.sh
+++ b/script/test.sh
@@ -29,10 +29,6 @@ if [ "$BINARY_OS" == "" ] || [ "$BINARY_ARCH" == "" ] ; then
         BINARY_OS=windows
         BINARY_ARCH=x86_64
         ;;
-    "Windows"* | "MINGW"*)
-        BINARY_OS=windows
-        BINARY_ARCH=x86
-        ;;
       *)
       echo "Sorry, os not determined"
       exit 1
@@ -40,24 +36,29 @@ if [ "$BINARY_OS" == "" ] || [ "$BINARY_ARCH" == "" ] ; then
     esac;
 fi
 
+if [ "$BINARY_OS" != "windows" ] ; then PATH_SEPERATOR=/ ; else PATH_SEPERATOR=\\; fi
+PATH_TO_BIN=.${PATH_SEPERATOR}pkg${PATH_SEPERATOR}pact${PATH_SEPERATOR}bin${PATH_SEPERATOR}
 
 tools=(
-  # pact 
+  pact
   pact-broker
   pact-message
   pact-mock-service
-  pact-plugin-cli
   pact-provider-verifier
   pact-stub-service
   pactflow
+  pact-plugin-cli
+  pact-stub-server
+  pact_verifier_cli
+  pact_mock_server_cli
 )
 
+test_cmd=""
 for tool in ${tools[@]}; do
   echo testing $tool
-  if [ "$BINARY_OS" != "windows" ] ; then echo "no bat file ext needed for $(uname -a)" ; else FILE_EXT=.bat; fi
-  if [ "$BINARY_OS" = "windows" ] && [ "$tool" = "pact-plugin-cli" ] ; then  FILE_EXT=.exe ; else echo "no exe file ext needed for $(uname -a)"; fi
+  if [ "$BINARY_OS" = "windows" ] ; then FILE_EXT=.bat; fi
+  if [ "$BINARY_OS" = "windows" ] && ([ "$tool" = "pact-plugin-cli" ] || [ "$tool" = "pact-stub-server" ] || [ "$tool" = "pact_verifier_cli" ] || [ "$tool" = "pact_mock_server_cli" ]) ; then  FILE_EXT=.exe ; fi
+  if [ "$tool" = "pact_verifier_cli" ] || [ "$tool" = "pact-mock-service" ]; then  test_cmd="--help" ; fi
   echo executing ${tool}${FILE_EXT} 
-  if [ "$BINARY_ARCH" = "x86" ] && [ "$tool" = "pact-plugin-cli" ] ; then  echo "skipping for x86" ; else ${tool}${FILE_EXT} help; fi
+  ${PATH_TO_BIN}${tool}${FILE_EXT} ${test_cmd};
 done
-
-

--- a/script/unpack-and-test.sh
+++ b/script/unpack-and-test.sh
@@ -29,10 +29,6 @@ if [ "$BINARY_OS" == "" ] || [ "$BINARY_ARCH" == "" ] ; then
         BINARY_OS=windows
         BINARY_ARCH=x86_64
         ;;
-    "Windows"* | "MINGW"*)
-        BINARY_OS=windows
-        BINARY_ARCH=x86
-        ;;
       *)
       echo "Sorry, os not determined"
       exit 1
@@ -40,6 +36,9 @@ if [ "$BINARY_OS" == "" ] || [ "$BINARY_ARCH" == "" ] ; then
     esac;
 fi
 
+if [[ "$BINARY_OS" == "windows" ]]; then
+    FILE_EXT=".zip"
+fi
 
 cd pkg
 rm -rf pact
@@ -50,22 +49,25 @@ if [ "$BINARY_OS" != "windows" ] ; then PATH_SEPERATOR=/ ; else PATH_SEPERATOR=\
 PATH_TO_BIN=.${PATH_SEPERATOR}pact${PATH_SEPERATOR}bin${PATH_SEPERATOR}
 
 tools=(
-  # pact 
+  pact 
   pact-broker
   pact-message
   pact-mock-service
-  pact-plugin-cli
   pact-provider-verifier
   pact-stub-service
   pactflow
+  pact-plugin-cli
+  pact-stub-server
+  pact_verifier_cli
+  pact_mock_server_cli
 )
 
+test_cmd=""
 for tool in ${tools[@]}; do
   echo testing $tool
-  if [ "$BINARY_OS" != "windows" ] ; then echo "no bat file ext needed for $(uname -a)" ; else FILE_EXT=.bat; fi
-  if [ "$BINARY_OS" = "windows" ] && [ "$tool" = "pact-plugin-cli" ] ; then  FILE_EXT=.exe ; else echo "no exe file ext needed for $(uname -a)"; fi
-  echo executing ${PATH_TO_BIN}${tool}${FILE_EXT} 
-  if [ "$BINARY_ARCH" = "x86" ] && [ "$tool" = "pact-plugin-cli" ] ; then  echo "skipping for x86" ; else ${PATH_TO_BIN}${tool}${FILE_EXT} help; fi
+  if [ "$BINARY_OS" = "windows" ] ; then FILE_EXT=.bat; fi
+  if [ "$BINARY_OS" = "windows" ] && ([ "$tool" = "pact-plugin-cli" ] || [ "$tool" = "pact-stub-server" ] || [ "$tool" = "pact_verifier_cli" ] || [ "$tool" = "pact_mock_server_cli" ]) ; then  FILE_EXT=.exe ; fi
+  if [ "$tool" = "pact_verifier_cli" ] || [ "$tool" = "pact-mock-service" ]; then  test_cmd="--help" ; fi
+  echo executing ${tool}${FILE_EXT} 
+  ${PATH_TO_BIN}${tool}${FILE_EXT} ${test_cmd};
 done
-
-

--- a/tasks/package.rake
+++ b/tasks/package.rake
@@ -5,10 +5,17 @@ PACKAGE_NAME = "pact"
 VERSION = File.read('VERSION').strip
 TRAVELING_RUBY_VERSION = "20240904-3.3.5"
 TRAVELING_RUBY_PKG_DATE = TRAVELING_RUBY_VERSION.split("-").first
-PLUGIN_CLI_VERSION = "0.1.2"
+TRAVELING_RB_VERSION = TRAVELING_RUBY_VERSION.split("-").last
+RUBY_COMPAT_VERSION = TRAVELING_RB_VERSION.split(".").first(2).join(".") + ".0"
+RUBY_MAJOR_VERSION = TRAVELING_RB_VERSION.split(".").first.to_i
+RUBY_MINOR_VERSION = TRAVELING_RB_VERSION.split(".")[1].to_i
+PLUGIN_CLI_VERSION = "0.1.3" # https://github.com/pact-foundation/pact-plugins/releases
+MOCK_SERVER_CLI_VERSION = "1.0.6" # https://github.com/pact-foundation/pact-core-mock-server/releases
+VERIFIER_CLI_VERSION = "1.2.0" # https://github.com/pact-foundation/pact-reference/releases
+STUB_SERVER_CLI_VERSION = "0.6.2" # https://github.com/pact-foundation/pact-stub-server/releases
 
 desc "Package pact-ruby-standalone for OSX, Linux x86_64 and windows x86_64"
-task :package => ['package:linux:x86_64','package:linux:arm64', 'package:osx:x86_64', 'package:osx:arm64','package:windows:x86_64','package:windows:x86']
+task :package => ['package:linux:x86_64','package:linux:arm64', 'package:osx:x86_64', 'package:osx:arm64','package:windows:x86_64']
 
 namespace :package do
   namespace :linux do
@@ -27,27 +34,23 @@ namespace :package do
   desc "Package pact-ruby-standalone for OS X x86_64"
   task :x86_64 => [:bundle_install, "build/traveling-ruby-#{TRAVELING_RUBY_VERSION}-osx-x86_64.tar.gz"] do
     create_package(TRAVELING_RUBY_VERSION, "osx-x86_64", "osx-x86_64", :unix)
-  end
+    end
 
   desc "Package pact-ruby-standalone for OS X arm64"
   task :arm64 => [:bundle_install, "build/traveling-ruby-#{TRAVELING_RUBY_VERSION}-osx-arm64.tar.gz"] do
     create_package(TRAVELING_RUBY_VERSION, "osx-arm64", "osx-arm64", :unix)
-  end
+    end
   end
   namespace :windows do
     desc "Package pact-ruby-standalone for windows x86_64"
     task :x86_64 => [:bundle_install, "build/traveling-ruby-#{TRAVELING_RUBY_VERSION}-windows-x86_64.tar.gz"] do
       create_package(TRAVELING_RUBY_VERSION, "windows-x86_64", "windows-x86_64", :windows)
     end
-    desc "Package pact-ruby-standalone for windows x86"
-    task :x86 => [:bundle_install, "build/traveling-ruby-#{TRAVELING_RUBY_VERSION}-windows-x86.tar.gz"] do
-      create_package(TRAVELING_RUBY_VERSION, "windows-x86", "windows-x86", :windows)
-    end
   end
   desc "Install gems to local directory"
   task :bundle_install do
-    if RUBY_VERSION !~ /^3\.3\./
-      abort "You can only 'bundle install' using Ruby 3.3.5, because that's what Traveling Ruby uses."
+    if RUBY_VERSION !~ /^#{RUBY_MAJOR_VERSION}\.#{RUBY_MINOR_VERSION}\./
+      abort "You can only 'bundle install' using Ruby #{RUBY_VERSION}, because that's what Traveling Ruby uses."
     end
     sh "rm -rf build/tmp"
     sh "mkdir -p build/tmp"
@@ -91,10 +94,6 @@ end
 file "build/traveling-ruby-#{TRAVELING_RUBY_VERSION}-windows-x86_64.tar.gz" do
   download_runtime(TRAVELING_RUBY_VERSION, "windows-x86_64")
 end
-file "build/traveling-ruby-#{TRAVELING_RUBY_VERSION}-windows-x86.tar.gz" do
-  download_runtime(TRAVELING_RUBY_VERSION, "windows-x86")
-end
-
 def create_package(version, source_target, package_target, os_type)
   package_dir = "#{PACKAGE_NAME}"
   package_name = "#{PACKAGE_NAME}-#{VERSION}-#{package_target}"
@@ -129,17 +128,20 @@ def create_package(version, source_target, package_target, os_type)
 
   remove_unnecessary_files package_dir
   install_plugin_cli package_dir, package_target
+  install_mock_server_cli package_dir, package_target
+  install_verifier_cli package_dir, package_target
+  install_stub_server_cli package_dir, package_target
 
   if !ENV['DIR_ONLY']
     sh "mkdir -p pkg"
 
-    if os_type == :unix
-      sh "tar -czf pkg/#{package_name}.tar.gz #{package_dir}"
-    else
-      sh "zip -9rq pkg/#{package_name}.zip #{package_dir}"
-    end
+  if os_type == :unix
+    sh "tar -czf pkg/#{package_name}.tar.gz #{package_dir}"
+  else
+    sh "zip -9rq pkg/#{package_name}.zip #{package_dir}"
+  end
 
-    sh "rm -rf #{package_dir}"
+  sh "rm -rf #{package_dir}"
   end
 end
 
@@ -221,8 +223,8 @@ def remove_unnecessary_files package_dir
 end
 
 def generate_readme
-  template = File.absolute_path("packaging/README.md.template")
-  script = File.absolute_path("packaging/generate_readme_contents.rb")
+  template = File.absolute_path('packaging/README.md.template')
+  script = File.absolute_path('packaging/generate_readme_contents.rb')
   Bundler.with_unbundled_env do
     sh "cd build/tmp && env VERSION=#{VERSION} bundle exec ruby #{script} #{template} > ../README.md"
   end
@@ -230,7 +232,7 @@ end
 
 def download_runtime(version, target)
   sh "cd build && curl -L -O --fail " +
-    "https://github.com/YOU54F/traveling-ruby/releases/download/rel-#{TRAVELING_RUBY_PKG_DATE}/traveling-ruby-#{version}-#{target}.tar.gz"
+     "https://github.com/YOU54F/traveling-ruby/releases/download/rel-#{TRAVELING_RUBY_PKG_DATE}/traveling-ruby-#{version}-#{target}.tar.gz"
 end
 
 def install_plugin_cli(package_dir, package_target)
@@ -244,16 +246,91 @@ def install_plugin_cli(package_dir, package_target)
     sh "gunzip -N -f #{package_dir}/bin/pact-plugin-cli.gz"
     sh "chmod +x #{package_dir}/bin/pact-plugin-cli"
   when "osx-x86_64"
-    sh "curl -L -o #{package_dir}/bin/pact-plugin-cli.gz https://github.com/pact-foundation/pact-plugins/releases/download/pact-plugin-cli-v#{PLUGIN_CLI_VERSION}/pact-plugin-cli-osx-x86_64.gz"
+    sh "curl -L -o #{package_dir}/bin/pact-plugin-cli.gz https://github.com/pact-foundation/pact-plugins/releases/download/pact-plugin-cli-v#{PLUGIN_CLI_VERSION}/pact-plugin-cli-macos-x86_64.gz"
     sh "gunzip -N -f #{package_dir}/bin/pact-plugin-cli.gz"
     sh "chmod +x #{package_dir}/bin/pact-plugin-cli"
   when "osx-arm64"
-    sh "curl -L -o #{package_dir}/bin/pact-plugin-cli.gz https://github.com/pact-foundation/pact-plugins/releases/download/pact-plugin-cli-v#{PLUGIN_CLI_VERSION}/pact-plugin-cli-osx-aarch64.gz"
+    sh "curl -L -o #{package_dir}/bin/pact-plugin-cli.gz https://github.com/pact-foundation/pact-plugins/releases/download/pact-plugin-cli-v#{PLUGIN_CLI_VERSION}/pact-plugin-cli-macos-aarch64.gz"
     sh "gunzip -N -f #{package_dir}/bin/pact-plugin-cli.gz"
     sh "chmod +x #{package_dir}/bin/pact-plugin-cli"
   when "windows-x86_64"
     sh "curl -L -o #{package_dir}/bin/pact-plugin-cli.exe.gz https://github.com/pact-foundation/pact-plugins/releases/download/pact-plugin-cli-v#{PLUGIN_CLI_VERSION}/pact-plugin-cli-windows-x86_64.exe.gz"
     sh "gunzip -N -f #{package_dir}/bin/pact-plugin-cli.exe.gz"
     sh "chmod +x #{package_dir}/bin/pact-plugin-cli.exe"
+  end
+end
+
+def install_mock_server_cli(package_dir, package_target)
+  case package_target
+  when "linux-x86_64"
+    sh "curl -L -o #{package_dir}/bin/pact_mock_server_cli.gz https://github.com/pact-foundation/pact-core-mock-server//releases/download/pact_mock_server_cli-v#{MOCK_SERVER_CLI_VERSION}/pact_mock_server_cli-linux-x86_64.gz"
+    sh "gunzip -N -f #{package_dir}/bin/pact_mock_server_cli.gz"
+    sh "chmod +x #{package_dir}/bin/pact_mock_server_cli"
+  when "linux-arm64"
+    sh "curl -L -o #{package_dir}/bin/pact_mock_server_cli.gz https://github.com/pact-foundation/pact-core-mock-server//releases/download/pact_mock_server_cli-v#{MOCK_SERVER_CLI_VERSION}/pact_mock_server_cli-linux-aarch64.gz"
+    sh "gunzip -N -f #{package_dir}/bin/pact_mock_server_cli.gz"
+    sh "chmod +x #{package_dir}/bin/pact_mock_server_cli"
+  when "osx-x86_64"
+    sh "curl -L -o #{package_dir}/bin/pact_mock_server_cli.gz https://github.com/pact-foundation/pact-core-mock-server//releases/download/pact_mock_server_cli-v#{MOCK_SERVER_CLI_VERSION}/pact_mock_server_cli-macos-x86_64.gz"
+    sh "gunzip -N -f #{package_dir}/bin/pact_mock_server_cli.gz"
+    sh "chmod +x #{package_dir}/bin/pact_mock_server_cli"
+  when "osx-arm64"
+    sh "curl -L -o #{package_dir}/bin/pact_mock_server_cli.gz https://github.com/pact-foundation/pact-core-mock-server//releases/download/pact_mock_server_cli-v#{MOCK_SERVER_CLI_VERSION}/pact_mock_server_cli-macos-aarch64.gz"
+    sh "gunzip -N -f #{package_dir}/bin/pact_mock_server_cli.gz"
+    sh "chmod +x #{package_dir}/bin/pact_mock_server_cli"
+  when "windows-x86_64"
+    sh "curl -L -o #{package_dir}/bin/pact_mock_server_cli.exe.gz https://github.com/pact-foundation/pact-core-mock-server//releases/download/pact_mock_server_cli-v#{MOCK_SERVER_CLI_VERSION}/pact_mock_server_cli-windows-x86_64.exe.gz"
+    sh "gunzip -N -f #{package_dir}/bin/pact_mock_server_cli.exe.gz"
+    sh "chmod +x #{package_dir}/bin/pact_mock_server_cli.exe"
+  end
+end
+
+def install_verifier_cli(package_dir, package_target)
+  case package_target
+  when "linux-x86_64"
+    sh "curl -L -o #{package_dir}/bin/pact_verifier_cli.gz https://github.com/pact-foundation/pact-reference/releases/download/pact_verifier_cli-v#{VERIFIER_CLI_VERSION}/pact_verifier_cli-linux-x86_64.gz"
+    sh "gunzip -N -f #{package_dir}/bin/pact_verifier_cli.gz"
+    sh "chmod +x #{package_dir}/bin/pact_verifier_cli"
+  when "linux-arm64"
+    sh "curl -L -o #{package_dir}/bin/pact_verifier_cli.gz https://github.com/pact-foundation/pact-reference/releases/download/pact_verifier_cli-v#{VERIFIER_CLI_VERSION}/pact_verifier_cli-linux-aarch64.gz"
+    sh "gunzip -N -f #{package_dir}/bin/pact_verifier_cli.gz"
+    sh "chmod +x #{package_dir}/bin/pact_verifier_cli"
+  when "osx-x86_64"
+    sh "curl -L -o #{package_dir}/bin/pact_verifier_cli.gz https://github.com/pact-foundation/pact-reference/releases/download/pact_verifier_cli-v#{VERIFIER_CLI_VERSION}/pact_verifier_cli-macos-x86_64.gz"
+    sh "gunzip -N -f #{package_dir}/bin/pact_verifier_cli.gz"
+    sh "chmod +x #{package_dir}/bin/pact_verifier_cli"
+  when "osx-arm64"
+    sh "curl -L -o #{package_dir}/bin/pact_verifier_cli.gz https://github.com/pact-foundation/pact-reference/releases/download/pact_verifier_cli-v#{VERIFIER_CLI_VERSION}/pact_verifier_cli-macos-aarch64.gz"
+    sh "gunzip -N -f #{package_dir}/bin/pact_verifier_cli.gz"
+    sh "chmod +x #{package_dir}/bin/pact_verifier_cli"
+  when "windows-x86_64"
+    sh "curl -L -o #{package_dir}/bin/pact_verifier_cli.exe.gz https://github.com/pact-foundation/pact-reference/releases/download/pact_verifier_cli-v#{VERIFIER_CLI_VERSION}/pact_verifier_cli-windows-x86_64.exe.gz"
+    sh "gunzip -N -f #{package_dir}/bin/pact_verifier_cli.exe.gz"
+    sh "chmod +x #{package_dir}/bin/pact_verifier_cli.exe"
+  end
+end
+
+def install_stub_server_cli(package_dir, package_target)
+  case package_target
+  when "linux-x86_64"
+    sh "curl -L -o #{package_dir}/bin/pact-stub-server.gz https://github.com/pact-foundation/pact-stub-server/releases/download/v#{STUB_SERVER_CLI_VERSION}/pact-stub-server-linux-x86_64.gz"
+    sh "gunzip -N -f #{package_dir}/bin/pact-stub-server.gz"
+    sh "chmod +x #{package_dir}/bin/pact-stub-server"
+  when "linux-arm64"
+    sh "curl -L -o #{package_dir}/bin/pact-stub-server.gz https://github.com/pact-foundation/pact-stub-server/releases/download/v#{STUB_SERVER_CLI_VERSION}/pact-stub-server-linux-aarch64.gz"
+    sh "gunzip -N -f #{package_dir}/bin/pact-stub-server.gz"
+    sh "chmod +x #{package_dir}/bin/pact-stub-server"
+  when "osx-x86_64"
+    sh "curl -L -o #{package_dir}/bin/pact-stub-server.gz https://github.com/pact-foundation/pact-stub-server/releases/download/v#{STUB_SERVER_CLI_VERSION}/pact-stub-server-osx-x86_64.gz"
+    sh "gunzip -N -f #{package_dir}/bin/pact-stub-server.gz"
+    sh "chmod +x #{package_dir}/bin/pact-stub-server"
+  when "osx-arm64"
+    sh "curl -L -o #{package_dir}/bin/pact-stub-server.gz https://github.com/pact-foundation/pact-stub-server/releases/download/v#{STUB_SERVER_CLI_VERSION}/pact-stub-server-osx-aarch64.gz"
+    sh "gunzip -N -f #{package_dir}/bin/pact-stub-server.gz"
+    sh "chmod +x #{package_dir}/bin/pact-stub-server"
+  when "windows-x86_64"
+    sh "curl -L -o #{package_dir}/bin/pact-stub-server.exe.gz https://github.com/pact-foundation/pact-stub-server/releases/download/v#{STUB_SERVER_CLI_VERSION}/pact-stub-server-windows-x86_64.exe.gz"
+    sh "gunzip -N -f #{package_dir}/bin/pact-stub-server.exe.gz"
+    sh "chmod +x #{package_dir}/bin/pact-stub-server.exe"
   end
 end


### PR DESCRIPTION
fixes #143 

Adds 

- pact_mock_server_cli (for v3/v4 pact consumer side testing inc plugins)
- pact-stub-server (for v3/v4 pact stub support)
- pact_verifier_cli (for v3/v4 pact verification inc plugins)

Drops

- x86 windows support. (no equiv rust executables)

Tree looks like

```
├── pact
├── pactflow
├── pact-broker
├── pact-message
├── pact-mock-service
├── pact-stub-service
├── pact-provider-verifier
├── pact_mock_server_cli
├── pact-stub-server
├── pact_verifier_cli
└── pact-plugin-cli
```

I propose that we also make this repo more generic, rather than pact-ruby-standalone, drop the ruby prefix

1. rename the repo to pact-standalone
    1. With long term view of deprecating ruby tooling, and replacing with rust. Only pact_broker-client / pactflow client require porting 
2. rename [homebrew-pact-ruby-standalone](https://github.com/pact-foundation/homebrew-pact-ruby-standalone) to homebrew-pact-standalone
    
