### PR TITLE
chore(ci): prevent duplicate ci triggers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,12 @@
 name: Build
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   build:
@@ -45,6 +51,6 @@ jobs:
     - name: test x86 package
       if: ${{ runner.os == 'Windows'}}
       run: ./script/unpack-and-test.sh
-      env: 
+      env:
         BINARY_OS: 'windows'
         BINARY_ARCH: 'x86'


### PR DESCRIPTION
Triggering on all 'push' and 'pull_request' events will result in duplicated CI runs in PRs (due to both conditions being met).

Instead, trigger only on pushes to `master`, or updates to PRs targetting `master`.