### PR TITLE
fix(ci): update Ruby version to 3.4.7 in release and update workflows

### DIFF
--- a/.github/workflows/manual_release.yml
+++ b/.github/workflows/manual_release.yml
@@ -35,7 +35,7 @@ jobs:
 
     - uses: ruby/setup-ruby@v1.310.0
       with:
-        ruby-version: 3.3.9
+        ruby-version: 3.4.7
 
     - name: Set up environment
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
 
     - uses: ruby/setup-ruby@v1.310.0
       with:
-        ruby-version: 3.3.9
+        ruby-version: 3.4.7
 
     - name: Set up environment
       run: |

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -15,7 +15,7 @@ jobs:
 
     - uses: ruby/setup-ruby@v1.310.0
       with:
-        ruby-version: 3.3.9
+        ruby-version: 3.4.7
 
     - name: Set up environment
       run: |


### PR DESCRIPTION
## Summary

- `release.yml`, `manual_release.yml`, and `update.yml` were still pinned to `ruby-version: 3.3.9` after the Traveling Ruby upgrade to 3.4.7 in #236
- This would cause the release and update workflows to fail with the same "You can only 'bundle install' using Ruby 3.4.7" error

## Changes

| Workflow | Before | After |
|---|---|---|
| `release.yml` | `3.3.9` | `3.4.7` |
| `manual_release.yml` | `3.3.9` | `3.4.7` |
| `update.yml` | `3.3.9` | `3.4.7` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)